### PR TITLE
Set github token from the environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ LPVS will start scanning automatically, then provide comments about the licenses
    Or alternatively build and run the Docker container with LPVS:
    ```bash
     docker build -t lpvs .
-    docker run -p 7896:7896 --name lpvs lpvs:latest
+    docker run -p 7896:7896 --name lpvs -e LPVS_GITHUB_TOKEN=<`github.token`> lpvs:latest
     ```
     For additional information about using Docker and tips, please check file [Docker_Usage](.github/Docker_Usage.md).
     

--- a/src/main/java/com/lpvs/service/GitHubService.java
+++ b/src/main/java/com/lpvs/service/GitHubService.java
@@ -45,6 +45,7 @@ public class GitHubService {
                     webhookConfig.getRepositoryName() + "/pulls/" + webhookConfig.getPullRequestId());
         }
         try {
+            if (GITHUB_AUTH_TOKEN.isEmpty()) setGithubTokenFromEnv();
             if (GITHUB_API_URL.isEmpty()) gitHub = GitHub.connect(GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             else gitHub = GitHub.connectToEnterpriseWithOAuth(GITHUB_API_URL, GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             GHRepository repository = gitHub.getRepository(webhookConfig.getRepositoryOrganization()+"/"
@@ -82,6 +83,7 @@ public class GitHubService {
 
     public void setPendingCheck(WebhookConfig webhookConfig) {
         try {
+            if (GITHUB_AUTH_TOKEN.isEmpty()) setGithubTokenFromEnv();
             if (GITHUB_API_URL.isEmpty()) gitHub = GitHub.connect(GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             else gitHub = GitHub.connectToEnterpriseWithOAuth(GITHUB_API_URL, GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             GHRepository repository = gitHub.getRepository(webhookConfig.getRepositoryOrganization() + "/"
@@ -95,6 +97,7 @@ public class GitHubService {
 
     public void setErrorCheck(WebhookConfig webhookConfig) {
         try {
+            if (GITHUB_AUTH_TOKEN.isEmpty()) setGithubTokenFromEnv();
             if (GITHUB_API_URL.isEmpty()) gitHub = GitHub.connect(GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             else gitHub = GitHub.connectToEnterpriseWithOAuth(GITHUB_API_URL, GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             GHRepository repository = gitHub.getRepository(webhookConfig.getRepositoryOrganization() + "/"
@@ -173,6 +176,7 @@ public class GitHubService {
         try {
             String repositoryName = webhookConfig.getRepositoryName();
             String repositoryOrganization = webhookConfig.getRepositoryOrganization();
+            if (GITHUB_AUTH_TOKEN.isEmpty()) setGithubTokenFromEnv();
             if (GITHUB_API_URL.isEmpty()) gitHub = GitHub.connect(GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             else gitHub = GitHub.connectToEnterpriseWithOAuth(GITHUB_API_URL, GITHUB_LOGIN, GITHUB_AUTH_TOKEN);
             GHRepository repository = gitHub.getRepository(repositoryOrganization + "/" + repositoryName);
@@ -201,6 +205,10 @@ public class GitHubService {
         }
         LOG.debug("MatchedLines: " + matchedLines);
         return matchedLines;
+    }
+
+    public void setGithubTokenFromEnv() {
+            if (System.getenv("LPVS_GITHUB_TOKEN") != null) GITHUB_AUTH_TOKEN = System.getenv("LPVS_GITHUB_TOKEN");
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

If `github.token` is not set from the `application.properties`, `LPVS` look for the value from `LPVS_GITHUB_TOKEN` env variable. 
The user can run LPVS docker container with `LPVS_GITHUB_TOKEN` env variable like below.
```sh
docker run --rm -p 7896:7896 --name lpvs -e LPVS_GITHUB_TOKEN=<TOKEN> lpvs:latest
```