### PR TITLE
Add protection for the github->action build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,18 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ The LPVS source code is distributed under the [MIT](https://opensource.org/licen
 ## Contributing
 
 You are welcome to contribute to LPVS project. 
-Contributing is also a great way to practice social coding at Github, study new technologies and enrich your public portfolio.
+Contributing is also a great way to practice social coding at Github, study new technologies and enrich your public portfolio.  
 [How to contribute code](.github/CONTRIBUTING.md)  
-[How to report a security vulnerability](.github/SECURITY.md)
+[How to report a security vulnerability](.github/SECURITY.md)  


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Add restrict permissions for GITHUB_TOKEN and pin actions to full length commit sha 

## Type of change

- [x] CI system update

**Test Configuration**:
* Java: v11
* LPVS Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
