### PR TITLE
GithubService::getRepositoryLicense tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,15 @@
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Support of static mocks present only in mockito-inline, not mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.7.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/lpvs/service/GitHubService.java
+++ b/src/main/java/com/lpvs/service/GitHubService.java
@@ -28,12 +28,17 @@ import java.util.List;
 @Service
 public class GitHubService {
 
-    @Value("${github.login}")
     private String GITHUB_LOGIN;
-    @Value("${github.token}")
     private String GITHUB_AUTH_TOKEN;
-    @Value("${github.api.url:}")
     private String GITHUB_API_URL;
+
+    public GitHubService(@Value("${github.login}") String GITHUB_LOGIN,
+                         @Value("${github.token}") String GITHUB_AUTH_TOKEN,
+                         @Value("${github.api.url:}") String GITHUB_API_URL) {
+        this.GITHUB_LOGIN = GITHUB_LOGIN;
+        this.GITHUB_AUTH_TOKEN = GITHUB_AUTH_TOKEN;
+        this.GITHUB_API_URL = GITHUB_API_URL;
+    }
 
     private static Logger LOG = LoggerFactory.getLogger(GitHubService.class);
 

--- a/src/test/java/com/lpvs/service/GitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/GitHubServiceTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
 package com.lpvs.service;
 
 import com.lpvs.entity.config.WebhookConfig;

--- a/src/test/java/com/lpvs/service/GitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/GitHubServiceTest.java
@@ -62,6 +62,7 @@ public class GitHubServiceTest {
 
         @Test
         public void testGetRepositoryLicense__ApiUrlAbsentLisencePresent() {
+
             try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
                 mocked_static_gh.when(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
 
@@ -130,6 +131,7 @@ public class GitHubServiceTest {
 
         @Test
         public void testGetRepositoryLicense__ApiUrlAbsentLisenceAbsent() {
+
             try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
                 mocked_static_gh.when(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
 
@@ -198,9 +200,7 @@ public class GitHubServiceTest {
 
         @Test
         public void testGetRepositoryLicense__ApiUrlPresentLisencePresent() {
-            // No specific settings before current test
 
-            // beginning of the test
             try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
                 mocked_static_gh.when(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
 
@@ -270,9 +270,7 @@ public class GitHubServiceTest {
 
         @Test
         public void testGetRepositoryLicense__ApiUrlPresentLisenceAbsent() {
-            // No specific settings before current test
 
-            // beginning of the test
             try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
                 mocked_static_gh.when(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
 
@@ -326,6 +324,7 @@ public class GitHubServiceTest {
 
         @Test
         public void testGetRepositoryLicense__ApiUrlAbsentCantAuthorize() {
+
             try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
                 mocked_static_gh.when(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN)).thenThrow(new IOException("test cant authorize"));
 
@@ -359,9 +358,7 @@ public class GitHubServiceTest {
 
         @Test
         public void testGetRepositoryLicense__ApiUrlPresentCantAuthorize() {
-            // No specific settings before current test
 
-            // beginning of the test
             try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
                 mocked_static_gh.when(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN)).thenThrow(new IOException("test cant authorize"));
 

--- a/src/test/java/com/lpvs/service/GitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/GitHubServiceTest.java
@@ -1,0 +1,379 @@
+package com.lpvs.service;
+
+import com.lpvs.entity.config.WebhookConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHLicense;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+
+public class GitHubServiceTest {
+    /**
+     * todo: decide if we need extra-dependency Junit-pioneer to mock System.getenv(),
+     *  and then possibly add test case for
+     *  `if (GITHUB_AUTH_TOKEN.isEmpty()) setGithubTokenFromEnv();`
+     *  https://stackoverflow.com/a/59635733/8463690
+     */
+
+
+    private static Logger LOG = LoggerFactory.getLogger(GitHubServiceTest.class);
+
+    @Nested
+    class TestGetRepositoryLicense__ApiUrlAbsentLisencePresent {
+
+        String GH_LOGIN = "test_login";
+        String GH_AUTH_TOKEN = "test_auth_token";
+        String GH_API_URL = "";
+        GitHubService gh_service = new GitHubService(GH_LOGIN, GH_AUTH_TOKEN, GH_API_URL);
+        WebhookConfig webhookConfig;
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        GHLicense mocked_license = mock(GHLicense.class);
+        String test_license_key = "test_license_key";
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName("LPVS");
+            webhookConfig.setRepositoryOrganization("Samsung");
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                when(mocked_repo.getLicense()).thenReturn(mocked_license);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getLicense error " + e);
+            }
+            when(mocked_license.getKey()).thenReturn(test_license_key);
+        }
+
+        @Test
+        public void testGetRepositoryLicense__ApiUrlAbsentLisencePresent() {
+            try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
+                mocked_static_gh.when(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
+
+                // main test
+                assertEquals(test_license_key, gh_service.getRepositoryLicense(webhookConfig));
+
+                // verification of calling methods on `Mock`s
+                // `mocked_static_gh` verify
+                mocked_static_gh.verify(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN), times(1));
+                mocked_static_gh.verifyNoMoreInteractions();
+
+                // `mocked_instance_gh` verify
+                try {
+                    verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+                } catch (IOException e) {
+                    LOG.error("mocked_instance_gh.getRepository error " + e);
+                }
+                verifyNoMoreInteractions(mocked_instance_gh);
+
+                // `mocked_repo` verify
+                try {
+                    verify(mocked_repo, times(1)).getLicense();
+                } catch (IOException e) {
+                    LOG.error("mocked_repo.getLicense error " + e);
+                }
+                verifyNoMoreInteractions(mocked_repo);
+
+                // `mocked_license` verify
+                verify(mocked_license, times(1)).getKey();
+                verifyNoMoreInteractions(mocked_license);
+            }
+        }
+    }
+
+    @Nested
+    class TestGetRepositoryLicense__ApiUrlAbsentLisenceAbsent {
+
+        String GH_LOGIN = "test_login";
+        String GH_AUTH_TOKEN = "test_auth_token";
+        String GH_API_URL = "";
+        GitHubService gh_service = new GitHubService(GH_LOGIN, GH_AUTH_TOKEN, GH_API_URL);
+        WebhookConfig webhookConfig;
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        // GHLicense mocked_license = mock(GHLicense.class);
+        // String test_license_key = "test_license_key";
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName("LPVS");
+            webhookConfig.setRepositoryOrganization("Samsung");
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                when(mocked_repo.getLicense()).thenReturn(null);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getLicense error " + e);
+            }
+            // when(mocked_license.getKey()).thenReturn(test_license_key);
+        }
+
+        @Test
+        public void testGetRepositoryLicense__ApiUrlAbsentLisenceAbsent() {
+            try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
+                mocked_static_gh.when(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
+
+                // main test
+                assertEquals("Proprietary", gh_service.getRepositoryLicense(webhookConfig));
+
+                // verification of calling methods on `Mock`s
+                // `mocked_static_gh` verify
+                mocked_static_gh.verify(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN), times(1));
+                mocked_static_gh.verifyNoMoreInteractions();
+
+                // `mocked_instance_gh` verify
+                try {
+                    verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+                } catch (IOException e) {
+                    LOG.error("mocked_instance_gh.getRepository error " + e);
+                }
+                verifyNoMoreInteractions(mocked_instance_gh);
+
+                // `mocked_repo` verify
+                try {
+                    verify(mocked_repo, times(1)).getLicense();
+                } catch (IOException e) {
+                    LOG.error("mocked_repo.getLicense error " + e);
+                }
+                verifyNoMoreInteractions(mocked_repo);
+
+                // // `mocked_license` verify
+                // verify (mocked_license, times(1)).getKey();
+                // verifyNoMoreI// nteractions(mocked_license);
+            }
+        }
+    }
+
+    @Nested
+    class TestGetRepositoryLicense__ApiUrlPresentLisencePresent {
+
+        String GH_LOGIN = "test_login";
+        String GH_AUTH_TOKEN = "test_auth_token";
+        String GH_API_URL = "test_api_url";
+        GitHubService gh_service = new GitHubService(GH_LOGIN, GH_AUTH_TOKEN, GH_API_URL);
+        WebhookConfig webhookConfig;
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        GHLicense mocked_license = mock(GHLicense.class);
+        String test_license_key = "test_license_key";
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName("LPVS");
+            webhookConfig.setRepositoryOrganization("Samsung");
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                when(mocked_repo.getLicense()).thenReturn(mocked_license);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getLicense error " + e);
+            }
+            when(mocked_license.getKey()).thenReturn(test_license_key);
+        }
+
+        @Test
+        public void testGetRepositoryLicense__ApiUrlPresentLisencePresent() {
+            // No specific settings before current test
+
+            // beginning of the test
+            try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
+                mocked_static_gh.when(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
+
+                // main test
+                assertEquals(test_license_key, gh_service.getRepositoryLicense(webhookConfig));
+
+                // verification of calling methods on `Mock`s
+                // `mocked_static_gh` verify
+                mocked_static_gh.verify(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN), times(1));
+                mocked_static_gh.verifyNoMoreInteractions();
+
+                // `mocked_instance_gh` verify
+                try {
+                    verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+                } catch (IOException e) {
+                    LOG.error("mocked_instance_gh.getRepository error " + e);
+                }
+                verifyNoMoreInteractions(mocked_instance_gh);
+
+                // `mocked_repo` verify
+                try {
+                    verify(mocked_repo, times(1)).getLicense();
+                } catch (IOException e) {
+                    LOG.error("mocked_repo.getLicense error " + e);
+                }
+                verifyNoMoreInteractions(mocked_repo);
+
+                // `mocked_license` verify
+                verify(mocked_license, times(1)).getKey();
+                verifyNoMoreInteractions(mocked_license);
+            }
+        }
+    }
+
+
+    @Nested
+    class TestGetRepositoryLicense__ApiUrlPresentLisenceAbsent {
+
+        String GH_LOGIN = "test_login";
+        String GH_AUTH_TOKEN = "test_auth_token";
+        String GH_API_URL = "test_api_url";
+        GitHubService gh_service = new GitHubService(GH_LOGIN, GH_AUTH_TOKEN, GH_API_URL);
+        WebhookConfig webhookConfig;
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        // GHLicense mocked_license = mock(GHLicense.class);
+        // String test_license_key = "test_license_key";
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName("LPVS");
+            webhookConfig.setRepositoryOrganization("Samsung");
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                when(mocked_repo.getLicense()).thenReturn(null);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getLicense error " + e);
+            }
+            // when(mocked_license.getKey()).thenReturn(test_license_key);
+        }
+
+        @Test
+        public void testGetRepositoryLicense__ApiUrlPresentLisenceAbsent() {
+            // No specific settings before current test
+
+            // beginning of the test
+            try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
+                mocked_static_gh.when(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN)).thenReturn(mocked_instance_gh);
+
+                // main test
+                assertEquals("Proprietary", gh_service.getRepositoryLicense(webhookConfig));
+
+                // verification of calling methods on `Mock`s
+                // `mocked_static_gh` verify
+                mocked_static_gh.verify(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN), times(1));
+                mocked_static_gh.verifyNoMoreInteractions();
+
+                // `mocked_instance_gh` verify
+                try {
+                    verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+                } catch (IOException e) {
+                    LOG.error("mocked_instance_gh.getRepository error " + e);
+                }
+                verifyNoMoreInteractions(mocked_instance_gh);
+
+                // `mocked_repo` verify
+                try {
+                    verify(mocked_repo, times(1)).getLicense();
+                } catch (IOException e) {
+                    LOG.error("mocked_repo.getLicense error " + e);
+                }
+                verifyNoMoreInteractions(mocked_repo);
+
+                // // `mocked_license` verify
+                // verify(mocked_license, times(1)).getKey();
+                // verifyNoMoreInteractions(mocked_license);
+            }
+        }
+    }
+
+
+    @Nested
+    class TestGetRepositoryLicense__ApiUrlAbsentCantAuthorize {
+
+        String GH_LOGIN = "test_login";
+        String GH_AUTH_TOKEN = "test_auth_token";
+        String GH_API_URL = "";
+        GitHubService gh_service = new GitHubService(GH_LOGIN, GH_AUTH_TOKEN, GH_API_URL);
+        WebhookConfig webhookConfig;
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName("LPVS");
+            webhookConfig.setRepositoryOrganization("Samsung");
+        }
+
+        @Test
+        public void testGetRepositoryLicense__ApiUrlAbsentCantAuthorize() {
+            try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
+                mocked_static_gh.when(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN)).thenThrow(new IOException("test cant authorize"));
+
+                // main test
+                assertEquals("Proprietary", gh_service.getRepositoryLicense(webhookConfig));
+
+                // verification of calling methods on `Mock`s
+                // `mocked_static_gh` verify
+                mocked_static_gh.verify(() -> GitHub.connect(GH_LOGIN, GH_AUTH_TOKEN), times(1));
+                mocked_static_gh.verifyNoMoreInteractions();
+            }
+        }
+    }
+
+
+    @Nested
+    class TestGetRepositoryLicense__ApiUrlPresentCantAuthorize {
+
+        String GH_LOGIN = "test_login";
+        String GH_AUTH_TOKEN = "test_auth_token";
+        String GH_API_URL = "test_api_url";
+        GitHubService gh_service = new GitHubService(GH_LOGIN, GH_AUTH_TOKEN, GH_API_URL);
+        WebhookConfig webhookConfig;
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName("LPVS");
+            webhookConfig.setRepositoryOrganization("Samsung");
+        }
+
+        @Test
+        public void testGetRepositoryLicense__ApiUrlPresentCantAuthorize() {
+            // No specific settings before current test
+
+            // beginning of the test
+            try (MockedStatic<GitHub> mocked_static_gh = mockStatic(GitHub.class)) {
+                mocked_static_gh.when(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN)).thenThrow(new IOException("test cant authorize"));
+
+                // main test
+                assertEquals("Proprietary", gh_service.getRepositoryLicense(webhookConfig));
+
+                // verification of calling methods on `Mock`s
+                // `mocked_static_gh` verify
+                mocked_static_gh.verify(() -> GitHub.connectToEnterpriseWithOAuth(GH_API_URL, GH_LOGIN, GH_AUTH_TOKEN), times(1));
+                mocked_static_gh.verifyNoMoreInteractions();
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Added unit test set (4 pcs) for the GithubService::getRepositoryLicense method. This step is required for the GitHub action infra setup.
Refactored creation of `GitHubService` in order to simplify unit testing.

New dependency:
`mockito-inline:4.7.0`

Needed for mock external library objects. `mockito-inline` instead of `mockito-core` is used, because only `mockito-inline` supports mocking static methods


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [x] Test Coverage update

# How Has This Been Tested?

**Test Configuration**:
* Java: v18
* LPVS Release: v1.x.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
