### PR TITLE
Make file path to license.json changeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,26 @@ LPVS will start scanning automatically, then provide comments about the licenses
 
 1. Install SCANOSS Python package by following the [guideline](https://github.com/scanoss/scanoss.py#installation).
 
-2. Fill in the lines of the `src/main/resources/application.properties` file:
+2. Fill in `licenses.json` file with the information about permitted, restricted, and prohibited licenses (mandatory) as well as their compatibility specifics (optional). 
+A template of the `licenses.json` file can be found in the repository at `src/main/resources/licenses.json`.
+
+3. Fill in the lines of the `src/main/resources/application.properties` file:
     ```text
-   # Used license scanner
+   # Used license scanner: scanoss (at the moment, only this scanner is supported)
     scanner=scanoss
-   # Used license conflicts source (take from 'licenses.json' ("json") 
-   # or from scanner response("scanner"))
+
+   # Path to the 'licenses.json' file which contains information about permitted,
+   # restricted and prohibited licenses. This file should be filled according to
+   # the template which could be found at 'src/main/resources/licenses.json'
+    license_filepath=
+
+   # Used license conflicts source:
+   # > option "json": take conflicts from 'licenses.json' (should be filled manually
+   # according to the template at 'src/main/resources/licenses.json')
+   # > option "scanner": take conflicts from the scanner response
     license_conflict=json
     ```
 
-3. Fill in `src/main/resources/licenses.json` file with the information about permitted, restricted, and prohibited licenses as well as their compatibility specifics. An example of the `licenses.json` file can be found in the repository.
-   
 4. Build LPVS application with Maven, then run it:
     ```bash
     mvn clean install

--- a/src/main/java/com/lpvs/service/LicenseService.java
+++ b/src/main/java/com/lpvs/service/LicenseService.java
@@ -25,6 +25,9 @@ import java.util.*;
 @Service
 public class LicenseService {
 
+    @Value("${license_filepath:classes/licenses.json}")
+    public String licenseFilePath;
+
     @Value("${license_conflict:json}")
     public String licenseConflictsSource;
 
@@ -41,7 +44,7 @@ public class LicenseService {
             // create Gson instance
             Gson gson = new Gson();
             // create a reader
-            Reader reader = Files.newBufferedReader(Paths.get("classes/licenses.json"));
+            Reader reader = Files.newBufferedReader(Paths.get(licenseFilePath));
             // convert JSON array to list of licenses
             licenses = new Gson().fromJson(reader, new TypeToken<List<LPVSLicense>>() {}.getType());
             // print info
@@ -170,6 +173,11 @@ public class LicenseService {
             Conflict<?, ?> conflict = (Conflict<?, ?>) o;
             return (l1.equals(conflict.l1) && l2.equals(conflict.l2)) ||
                     (l1.equals(conflict.l2) && l2.equals(conflict.l1));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(l1, l2);
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,10 +2,16 @@
 ###                                     LPVS Configuration                                           ##
 #######################################################################################################
 server.port=7896
+
 # Used scanner name
 scanner=scanoss
-# license_conflict: json or scanner
+
+# Path to the 'licenses.json' file
+license_filepath=classes/licenses.json
+
+# Source of the license conflicts information: json or scanner
 license_conflict=json
+
 # GitHub settings
 github.login=
 github.token=


### PR DESCRIPTION
Signed-off-by: Oleg Kopysov <o.kopysov@samsung.com>

# Description

To run LPVS in Docker container, we need to provide the possibility to set the path to the `licenses.json` by the user (previously, the path was hardcoded). In current PR I make the path changeable. In further PRs I will provide the possibility to set the path as an environment variable (as well as token, login, etc.)
Also, I want to fix one of the LGTM issue from https://lgtm.com/projects/g/Samsung/LPVS/alerts/?mode=list (Class Conflict overrides equals but not hashCode)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactoring
- [X] Documentation update
- [X] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update

# How Has This Been Tested?
All possible combinations of licenses.json paths were tested.

**Test Configuration**:
* Java: v11
* LPVS Release: v1.0.0

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
