### PR TITLE
Run scan logic if github secret and lpvs secret are the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ LPVS license scan shall be enabled on a project via GitHub Hooks:
 - fill in Payload URL with: `http://<IP where LPVS is running>:7896/webhooks`
 - specify content type: `application/json`
 - fill in `Secret` field with the passphrase: `LPVS`
+  - the same passphrase must be saved in `github.secret` of LPVS backend `application.properties` file
 - select `Let me select individual events` -> `Pull requests` (make sure that only `Pull requests` is selected)
 - make it `Active`
 - press `Add Webhook`
@@ -51,6 +52,10 @@ A template of the `licenses.json` file can be found in the repository at `src/ma
 
 3. Fill in the lines of the `src/main/resources/application.properties` file:
     ```text
+   # Fill in the properties associated with github (github.token and github.secret required).
+   github.token=
+   github.secret=LPVS
+
    # Used license scanner: scanoss (at the moment, only this scanner is supported)
     scanner=scanoss
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
 
         <!-- Support of static mocks present only in mockito-inline, not mockito-core -->
         <dependency>

--- a/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
+++ b/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
@@ -12,9 +12,12 @@ import com.lpvs.service.GitHubService;
 import com.lpvs.service.QueueService;
 import com.lpvs.util.WebhookUtil;
 import com.lpvs.entity.ResponseWrapper;
+
+import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -24,10 +27,14 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
 import java.util.Date;
-
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 @RestController
 public class GitHubWebhooksController {
+    @Value("${github.secret:}")
+    private String GITHUB_SECRET;
+
     private QueueService queueService;
 
     private GitHubService gitHubService;
@@ -37,6 +44,7 @@ public class GitHubWebhooksController {
     private static final String SIGNATURE = "X-Hub-Signature";
     private static final String SUCCESS = "Success";
     private static final String ERROR = "Error";
+    private static final String ALGORITHM = "HmacSHA1";
 
     public GitHubWebhooksController(QueueService queueService, GitHubService gitHubService) {
         this.queueService = queueService;
@@ -44,11 +52,13 @@ public class GitHubWebhooksController {
     }
 
     @RequestMapping(value = "/webhooks", method = RequestMethod.POST)
-    public ResponseEntity<ResponseWrapper> gitHubWebhooks(@RequestHeader(SIGNATURE) String signature, @RequestBody String payload) throws InterruptedException {
+    public ResponseEntity<ResponseWrapper> gitHubWebhooks(@RequestHeader(SIGNATURE) String signature, @RequestBody String payload) throws Exception {
         LOG.info("New webhook request received");
 
         // if signature is empty return 401
         if (!StringUtils.hasText(signature)) {
+            return new ResponseEntity<>(new ResponseWrapper(ERROR), HttpStatus.FORBIDDEN);
+        } else if (!GITHUB_SECRET.isBlank() && wrongSecret(signature, payload)) {
             return new ResponseEntity<>(new ResponseWrapper(ERROR), HttpStatus.FORBIDDEN);
         }
 
@@ -65,5 +75,19 @@ public class GitHubWebhooksController {
         }
         LOG.info("Response sent");
         return new ResponseEntity<>(new ResponseWrapper(SUCCESS), HttpStatus.OK);
+    }
+
+    public boolean wrongSecret(String signature, String payload) throws Exception {
+        String lpvsSecret = signature.split("=",2)[1];
+
+        SecretKeySpec key = new SecretKeySpec(GITHUB_SECRET.getBytes("utf-8"), ALGORITHM);
+        Mac mac = Mac.getInstance(ALGORITHM);
+        mac.init(key);
+        String githubSecret = Hex.encodeHexString(mac.doFinal(payload.getBytes()));
+
+        LOG.info("lpvs   signature: " + lpvsSecret);
+        LOG.info("github signature: " + githubSecret);
+
+        return !lpvsSecret.equals(githubSecret);
     }
 }

--- a/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
+++ b/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
@@ -58,7 +58,7 @@ public class GitHubWebhooksController {
         // if signature is empty return 401
         if (!StringUtils.hasText(signature)) {
             return new ResponseEntity<>(new ResponseWrapper(ERROR), HttpStatus.FORBIDDEN);
-        } else if (!GITHUB_SECRET.isBlank() && wrongSecret(signature, payload)) {
+        } else if (!GITHUB_SECRET.trim().isEmpty() && wrongSecret(signature, payload)) {
             return new ResponseEntity<>(new ResponseWrapper(ERROR), HttpStatus.FORBIDDEN);
         }
 

--- a/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
+++ b/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
@@ -41,10 +41,10 @@ public class GitHubWebhooksController {
 
     private static Logger LOG = LoggerFactory.getLogger(GitHubWebhooksController.class);
 
-    private static final String SIGNATURE = "X-Hub-Signature";
+    private static final String SIGNATURE = "X-Hub-Signature-256";
     private static final String SUCCESS = "Success";
     private static final String ERROR = "Error";
-    private static final String ALGORITHM = "HmacSHA1";
+    private static final String ALGORITHM = "HmacSHA256";
 
     public GitHubWebhooksController(QueueService queueService, GitHubService gitHubService) {
         this.queueService = queueService;

--- a/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
+++ b/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
@@ -46,9 +46,10 @@ public class GitHubWebhooksController {
     private static final String ERROR = "Error";
     private static final String ALGORITHM = "HmacSHA256";
 
-    public GitHubWebhooksController(QueueService queueService, GitHubService gitHubService) {
+    public GitHubWebhooksController(QueueService queueService, GitHubService gitHubService, @Value("${github.secret:}") String GITHUB_SECRET) {
         this.queueService = queueService;
         this.gitHubService = gitHubService;
+        this.GITHUB_SECRET = GITHUB_SECRET;
     }
 
     @RequestMapping(value = "/webhooks", method = RequestMethod.POST)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,7 @@ license_conflict=json
 github.login=
 github.token=
 github.api.url=
+github.secret=LPVS
 
 # Used Core Pool Size
 lpvs.cores=8

--- a/src/test/java/com/lpvs/controller/GitHubWebhooksControllerTest.java
+++ b/src/test/java/com/lpvs/controller/GitHubWebhooksControllerTest.java
@@ -20,20 +20,20 @@ import static org.mockito.Mockito.mock;
 
 public class GitHubWebhooksControllerTest {
 
-    private static final String SIGNATURE = "X-Hub-Signature";
+    private static final String SIGNATURE = "X-Hub-Signature-256";
     private static final String SUCCESS = "Success";
     private static final String ERROR = "Error";
 
     QueueService mocked_instance_queueServ = mock(QueueService.class);
     GitHubService mocked_instance_ghServ = mock(GitHubService.class);
-    GitHubWebhooksController gitHubWebhooksController = new GitHubWebhooksController(mocked_instance_queueServ, mocked_instance_ghServ);
+    GitHubWebhooksController gitHubWebhooksController = new GitHubWebhooksController(mocked_instance_queueServ, mocked_instance_ghServ, "");
 
     @Test
     public void noSignatureTest() {
         ResponseEntity actual;
         try {
             actual = gitHubWebhooksController.gitHubWebhooks(null, null);
-        } catch( InterruptedException e) {
+        } catch( Exception e) {
             actual = null;
         }
         ResponseEntity expected = new ResponseEntity<>(new ResponseWrapper(ERROR), HttpStatus.FORBIDDEN);
@@ -45,7 +45,7 @@ public class GitHubWebhooksControllerTest {
         ResponseEntity actual;
         try {
             actual = gitHubWebhooksController.gitHubWebhooks(SIGNATURE, null);
-        } catch( InterruptedException e) {
+        } catch( Exception e) {
             actual = null;
         }
         ResponseEntity expected = new ResponseEntity<>(new ResponseWrapper(SUCCESS), HttpStatus.OK);
@@ -80,7 +80,7 @@ public class GitHubWebhooksControllerTest {
 
         try {
             actual = gitHubWebhooksController.gitHubWebhooks(SIGNATURE, json_to_test);
-        } catch( InterruptedException e) {
+        } catch( Exception e) {
             actual = null;
         }
         ResponseEntity expected = new ResponseEntity<>(new ResponseWrapper(SUCCESS), HttpStatus.OK);


### PR DESCRIPTION
# Description

Scanning will be carried out when github secret and lpvs secret are the same.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
1. Add `github.secret` to the `application.properties` file like below.
```
github.secret=lpvs
```
2. Run LPVS
3. Check the LPVS log like below.
```
2022-08-31 16:48:31.188  INFO 71382 --- [nio-7896-exec-1] c.l.controller.GitHubWebhooksController  : lpvs   signature: 42c493a2e4062a2fb506083432e1e9208e44000acfd04971097ac62a1779a0d5
2022-08-31 16:48:31.188  INFO 71382 --- [nio-7896-exec-1] c.l.controller.GitHubWebhooksController  : github signature: 42c493a2e4062a2fb506083432e1e9208e44000acfd04971097ac62a1779a0d5
```

**Test Configuration**:
* Java: v11
* LPVS Release: v1.0.0

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
