### PR TITLE
Added log output about used LPVS version and core pool size

### DIFF
--- a/src/main/java/com/lpvs/LicensePreValidationSystem.java
+++ b/src/main/java/com/lpvs/LicensePreValidationSystem.java
@@ -7,6 +7,8 @@
 
 package com.lpvs;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -26,19 +28,29 @@ public class LicensePreValidationSystem {
 
     private int corePoolSize;
 
-    public LicensePreValidationSystem(@Value("${lpvs.cores:8}") int corePoolSize) {
+    private String lpvsVersion;
+
+    private static Logger LOG = LoggerFactory.getLogger(LicensePreValidationSystem.class);
+
+    public LicensePreValidationSystem(@Value("${lpvs.cores:8}") int corePoolSize,
+                                      @Value("${lpvs.version:}") String lpvsVersion) {
         this.corePoolSize = corePoolSize;
+        this.lpvsVersion = lpvsVersion;
     }
 
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(LicensePreValidationSystem.class);
+
+
         app.run(args);
     }
 
     @Bean("threadPoolTaskExecutor")
     public TaskExecutor getAsyncExecutor(){
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        LOG.info("License Pre-Validation Service (LPVS) version " + lpvsVersion + " is running.");
         executor.setCorePoolSize(corePoolSize);
+        LOG.info("Used core pool size is " + corePoolSize);
         executor.setThreadNamePrefix("LPVS-ASYNC::");
         return executor;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ github.secret=LPVS
 
 # Used Core Pool Size
 lpvs.cores=8
+
+# Version of the LPVS
+lpvs.version=1.0.0

--- a/src/test/java/com/lpvs/LicensePreValidationSystemTest.java
+++ b/src/test/java/com/lpvs/LicensePreValidationSystemTest.java
@@ -23,7 +23,7 @@ public class LicensePreValidationSystemTest {
 
     @BeforeEach
     void setUp() {
-        licensePreValidationSystem = new LicensePreValidationSystem(42);
+        licensePreValidationSystem = new LicensePreValidationSystem(42, "1.0.0");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Oleg Kopysov <o.kopysov@samsung.com>

# Description

Added log output about used LPVS version and core pool size.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update

# How Has This Been Tested?
```
2022-09-07 16:16:25.753  INFO 28068 --- [           main] com.lpvs.LicensePreValidationSystem      : License Pre-Validation Service (LPVS) version 1.0.0 is running.
2022-09-07 16:16:25.753  INFO 28068 --- [           main] com.lpvs.LicensePreValidationSystem      : Used core pool size is 8

```

**Test Configuration**:
* Java: v11
* LPVS Release: v1.0.0

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
