### PR TITLE
GithubService:: `commentResults` and `getMatchedLinesAsLink` tests

### DIFF
--- a/src/main/java/com/lpvs/service/GitHubService.java
+++ b/src/main/java/com/lpvs/service/GitHubService.java
@@ -206,7 +206,7 @@ public class GitHubService {
         prefix = prefix.concat("#L");
         for (String lineInfo : file.getMatchedLines().split(",")){
             String link = prefix+lineInfo.replace('-','L');
-            matchedLines = matchedLines.concat("<a target=\"_blank\" href=\"" + link + "\">" + lineInfo + "</a> ");
+            matchedLines = matchedLines.concat("<a target=\"_blank\" href=\"" + link + "\">" + lineInfo + "</a>");
         }
         LOG.debug("MatchedLines: " + matchedLines);
         return matchedLines;

--- a/src/test/java/com/lpvs/service/GitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/GitHubServiceTest.java
@@ -108,8 +108,8 @@ public class GitHubServiceTest {
                     return;
                 }
             }
-            LOG.debug(expected_arg.replace("\n", "\\n"));
-            LOG.debug(comment_calls.get(0).arg.replace("\n", "\\n"));
+            LOG.error(expected_arg.replace("\n", "\\n"));
+            LOG.error(comment_calls.get(0).arg.replace("\n", "\\n"));
 
             // if not found
             fail("Call with arg " + expected_arg + " haven't passed verification");

--- a/src/test/java/com/lpvs/service/GitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/GitHubServiceTest.java
@@ -7,6 +7,8 @@
 
 package com.lpvs.service;
 
+import com.lpvs.entity.LPVSFile;
+import com.lpvs.entity.LPVSLicense;
 import com.lpvs.entity.config.WebhookConfig;
 import com.lpvs.entity.enums.PullRequestAction;
 import com.lpvs.util.FileUtil;
@@ -19,9 +21,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -77,6 +83,45 @@ public class GitHubServiceTest {
 
         @Override
         public GHCommitPointer getHead() { return mockedGetHead; }
+
+        static class CommentCall {
+            String arg;
+            boolean checked = false;
+
+            CommentCall(String arg) {
+                this.arg = arg;
+            }
+        }
+        
+        private final List<CommentCall> comment_calls = new ArrayList<>();
+
+        @Override
+        public GHIssueComment comment(String message) {
+            comment_calls.add(new CommentCall(message));
+            return null;
+        }
+
+        public void verifyCommentCall(String expected_arg) {
+            for (CommentCall c : comment_calls) {
+                if (c.arg.equals(expected_arg) && !c.checked) {
+                    c.checked = true;
+                    return;
+                }
+            }
+            LOG.debug(expected_arg.replace("\n", "\\n"));
+            LOG.debug(comment_calls.get(0).arg.replace("\n", "\\n"));
+
+            // if not found
+            fail("Call with arg " + expected_arg + " haven't passed verification");
+        }
+
+        public void verifyNoMoreCommentCalls() {
+            for (CommentCall c : comment_calls) {
+                if (!c.checked) {
+                    fail("There is still not checked call with arg " + c.arg);
+                }
+            }
+        }
 
     }
 
@@ -1080,6 +1125,460 @@ public class GitHubServiceTest {
     }
 
     @Nested
+    class TestCommentResults__PrAbsent {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        GHPullRequest mocked_pr_1;
+        GHPullRequest mocked_pr_2;
+        final String url_pr_1 = "https://api.github.com/repos/Samsung/LPVS/pulls/18";
+        final String url_pr_2 = "https://api.github.com/repos/Samsung/LPVS/pulls/19";
+        WebhookConfig webhookConfig;
+        final String repo_org = "Samsung";
+        final String repo_name = "LPVS";
+        final String url_pr_3 = "https://api.github.com/repos/Samsung/LPVS/pulls/20";
+
+        @BeforeEach
+        void setUp() {
+            // set `private static GitHub gitHub;` value
+            try {
+                Field staticPrivateGithub = GitHubService.class.getDeclaredField("gitHub");
+                staticPrivateGithub.setAccessible(true);
+                staticPrivateGithub.set(null, mocked_instance_gh);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                LOG.error("TestCommentResults__PrAbsent.setUp() error " + e);
+                fail();
+            }
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName(repo_name);
+            webhookConfig.setRepositoryOrganization(repo_org);
+            webhookConfig.setPullRequestAPIUrl(url_pr_3);
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                mocked_pr_1 = new GHPullRequestOurMock(new URL(url_pr_1), null, null, -1, null);
+                mocked_pr_2 = new GHPullRequestOurMock(new URL(url_pr_2), null, null, -1, null);
+            } catch (MalformedURLException e) {
+                LOG.error("TestCommentResults__PrAbsent.setUp() error " + e);
+                fail();
+            }
+            try {
+                when(mocked_repo.getPullRequests(GHIssueState.OPEN)).thenReturn(Arrays.asList(mocked_pr_1, mocked_pr_2));
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getPullRequests error " + e);
+            }
+        }
+
+        @Test
+        public void testCommentResults__PrAbsent() {
+            // main test
+            gh_service.commentResults(webhookConfig, null, null);
+
+            // `mocked_instance_gh` verify
+            try {
+                verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__PrAbsent.testCommentResults__PrAbsent() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_instance_gh);
+
+            // `mocked_repo` verify
+            try {
+                verify(mocked_repo, times(1)).getPullRequests(GHIssueState.OPEN);
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__PrAbsent.testCommentResults__PrAbsent() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_repo);
+        }
+    }
+
+    @Nested
+    class TestCommentResults__CantAuthorize {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        WebhookConfig webhookConfig;
+        final String repo_org = "Samsung";
+        final String repo_name = "LPVS";
+
+        @BeforeEach
+        void setUp() {
+            // set `private static GitHub gitHub;` value
+            try {
+                Field staticPrivateGithub = GitHubService.class.getDeclaredField("gitHub");
+                staticPrivateGithub.setAccessible(true);
+                staticPrivateGithub.set(null, mocked_instance_gh);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                LOG.error("TestCommentResults__CantAuthorize.setUp() error " + e);
+                fail();
+            }
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName(repo_name);
+            webhookConfig.setRepositoryOrganization(repo_org);
+
+            try {
+                when(mocked_instance_gh
+                        .getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName()))
+                        .thenThrow(new IOException("Test exception for TestCommentResults__CantAuthorize. Normal behavior."));
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+        }
+
+        @Test
+        public void testCommentResults__CantAuthorize() {
+            // main test
+            gh_service.commentResults(webhookConfig, null, null);
+
+            // `mocked_instance_gh` verify
+            try {
+                verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__CantAuthorize.testCommentResults__CantAuthorize() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_instance_gh);
+        }
+    }
+
+    @Nested
+    class TestCommentResults__ScanResultsEmpty {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        GHPullRequest mocked_pr_1;
+        GHPullRequest mocked_pr_2;
+        final String url_pr_1 = "https://api.github.com/repos/Samsung/LPVS/pulls/18";
+        final String url_pr_2 = "https://api.github.com/repos/Samsung/LPVS/pulls/19";
+        WebhookConfig webhookConfig;
+        final String repo_org = "Samsung";
+        final String repo_name = "LPVS";
+        final String commit_sha = "895337e89ae103ff2d18c9e0d93709f743226afa";
+
+        @BeforeEach
+        void setUp() {
+            // set `private static GitHub gitHub;` value
+            try {
+                Field staticPrivateGithub = GitHubService.class.getDeclaredField("gitHub");
+                staticPrivateGithub.setAccessible(true);
+                staticPrivateGithub.set(null, mocked_instance_gh);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                LOG.error("TestCommentResults__ScanResultsEmpty.setUp() error " + e);
+                fail();
+            }
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName(repo_name);
+            webhookConfig.setRepositoryOrganization(repo_org);
+            webhookConfig.setPullRequestAPIUrl(url_pr_2);
+            webhookConfig.setHeadCommitSHA(commit_sha);
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                mocked_pr_1 = new GHPullRequestOurMock(new URL(url_pr_1), null, null, -1, null);
+                mocked_pr_2 = new GHPullRequestOurMock(new URL(url_pr_2), null, null, -1, null);
+            } catch (MalformedURLException e) {
+                LOG.error("TestCommentResults__ScanResultsEmpty.setUp() error " + e);
+                fail();
+            }
+            try {
+                when(mocked_repo.getPullRequests(GHIssueState.OPEN)).thenReturn(Arrays.asList(mocked_pr_1, mocked_pr_2));
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getPullRequests error " + e);
+            }
+        }
+
+        @Test
+        public void testCommentResults__ScanResultsEmpty() {
+            // main test
+            gh_service.commentResults(webhookConfig, List.of(), null);
+
+            // `mocked_instance_gh` verify
+            try {
+                verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__ScanResultsEmpty.testCommentResults__ScanResultsEmpty() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_instance_gh);
+
+            // `mocked_repo` verify
+            try {
+                verify(mocked_repo, times(1)).getPullRequests(GHIssueState.OPEN);
+                verify(mocked_repo, times(1)).createCommitStatus(commit_sha, GHCommitState.SUCCESS, null,
+                        "No license issue detected", "[Open Source License Validation]");
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__ScanResultsEmpty.testCommentResults__ScanResultsEmpty() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_repo);
+        }
+    }
+
+    @Nested
+    class TestCommentResults__ProhibitedPresentConflictsPresent {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        GHPullRequest mocked_pr_1;
+        GHPullRequest mocked_pr_2;
+        final String url_pr_1 = "https://api.github.com/repos/Samsung/LPVS/pulls/18";
+        final String url_pr_2 = "https://api.github.com/repos/Samsung/LPVS/pulls/19";
+
+        // `webhookConfig`
+        WebhookConfig webhookConfig;
+        final String repo_org = "Samsung";
+        final String repo_name = "LPVS";
+        final String commit_sha = "895337e89ae103ff2d18c9e0d93709f743226afa";
+        final String repository_url = "https://github.com/Samsung/LPVS";
+
+        // `lpvs_file_1`
+        LPVSFile lpvs_file_1;
+        final String file_url_1 = "https://github.com/Samsung/LPVS/tree/main/src/main/java/com/lpvs/service/GitHubService.java";
+        final String file_path_1 = "src/main/java/com/lpvs/service/GitHubService.java";
+        final String snippet_match_1 = "/**\n" +
+                " * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.\n" +
+                " *\n" +
+                " * Use of this source code is governed by a MIT license that can be\n" +
+                " * found in the LICENSE file.\n" +
+                " */\n";
+        final String matched_lines_1 = "1-6";
+        final String component_1 = "LPVS::Services";
+
+        // `lpvs_file_1`
+        LPVSLicense lpvs_license_1;
+        final String license_name_1 = "MIT License";
+        final String spdx_id_1 = "MIT";
+        final String access_1 = "PROHIBITED";
+        final String checklist_url_1 = "https://opensource.org/licenses/MIT";
+
+        // `conflict_1`
+        LicenseService.Conflict<String, String> conflict_1;
+        final String conflict_1_l1 = "MIT";
+        final String conflict_1_l2 = "Apache-1.0";
+
+        final String expected_comment = "**\\[Open Source License Validation\\]** Potential license problem(s) detected \n\n" +
+                "**Detected licenses:**\n\n\n" +
+                "**File:** src/main/java/com/lpvs/service/GitHubService.java\n" +
+                "**License(s):** <a target=\"_blank\" href=\"https://opensource.org/licenses/MIT\">MIT</a> (prohibited)\n" +
+                "**Component:** LPVS::Services (https://github.com/Samsung/LPVS/tree/main/src/main/java/com/lpvs/service/GitHubService.java)\n" +
+                "**Matched Lines:** <a target=\"_blank\" href=\"https://github.com/Samsung/LPVS/blob/895337e89ae103ff2d18c9e0d93709f743226afa/src/main/java/com/lpvs/service/GitHubService.java#L1L6\">1-6</a>\n" +
+                "**Snippet Match:** /**\n" +
+                " * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.\n" +
+                " *\n" +
+                " * Use of this source code is governed by a MIT license that can be\n" +
+                " * found in the LICENSE file.\n" +
+                " */\n\n\n\n\n" +
+                "**Detected license conflicts:**\n\n\n" +
+                "<ul><li>MIT and Apache-1.0</li></ul>\n";
+
+        @BeforeEach
+        void setUp() {
+            // set `private static GitHub gitHub;` value
+            try {
+                Field staticPrivateGithub = GitHubService.class.getDeclaredField("gitHub");
+                staticPrivateGithub.setAccessible(true);
+                staticPrivateGithub.set(null, mocked_instance_gh);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                LOG.error("TestCommentResults__ProhibitedPresentConflictsPresent.setUp() error " + e);
+                fail();
+            }
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName(repo_name);
+            webhookConfig.setRepositoryOrganization(repo_org);
+            webhookConfig.setPullRequestAPIUrl(url_pr_2);
+            webhookConfig.setHeadCommitSHA(commit_sha);
+            webhookConfig.setRepositoryUrl(repository_url);
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                mocked_pr_1 = new GHPullRequestOurMock(new URL(url_pr_1), null, null, -1, null);
+                mocked_pr_2 = new GHPullRequestOurMock(new URL(url_pr_2), null, null, -1, null);
+            } catch (MalformedURLException e) {
+                LOG.error("TestCommentResults__ProhibitedPresentConflictsPresent.setUp() error " + e);
+                fail();
+            }
+            try {
+                when(mocked_repo.getPullRequests(GHIssueState.OPEN)).thenReturn(Arrays.asList(mocked_pr_1, mocked_pr_2));
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getPullRequests error " + e);
+            }
+
+            lpvs_license_1 = new LPVSLicense(1L, license_name_1, spdx_id_1, access_1, checklist_url_1, List.of());
+            lpvs_file_1 = new LPVSFile(1L, file_url_1, file_path_1, snippet_match_1, matched_lines_1, Set.of(lpvs_license_1), component_1);
+            conflict_1 = new LicenseService.Conflict<>(conflict_1_l1, conflict_1_l2);
+        }
+
+        @Test
+        public void testCommentResults__ProhibitedPresentConflictsPresent() {
+            // main test
+            gh_service.commentResults(webhookConfig, List.of(lpvs_file_1), List.of(conflict_1));
+
+            // `mocked_instance_gh` verify
+            try {
+                verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__ProhibitedPresentConflictsPresent.testCommentResults__ProhibitedPresentConflictsPresent() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_instance_gh);
+
+            // `mocked_repo` verify
+            try {
+                verify(mocked_repo, times(1)).getPullRequests(GHIssueState.OPEN);
+                verify(mocked_repo, times(1)).createCommitStatus(commit_sha, GHCommitState.FAILURE, null,
+                        "Potential license problem(s) detected", "[Open Source License Validation]");
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__ProhibitedPresentConflictsPresent.testCommentResults__ProhibitedPresentConflictsPresent() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_repo);
+
+            // `mocked_pr_2` verify
+            ((GHPullRequestOurMock)mocked_pr_2).verifyCommentCall(expected_comment);
+            ((GHPullRequestOurMock)mocked_pr_2).verifyNoMoreCommentCalls();
+        }
+    }
+
+    @Nested
+    class TestCommentResults__ProhibitedAbsentConflictsAbsent {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+        GitHub mocked_instance_gh = mock(GitHub.class);
+        GHRepository mocked_repo = mock(GHRepository.class);
+        GHPullRequest mocked_pr_1;
+        GHPullRequest mocked_pr_2;
+        final String url_pr_1 = "https://api.github.com/repos/Samsung/LPVS/pulls/18";
+        final String url_pr_2 = "https://api.github.com/repos/Samsung/LPVS/pulls/19";
+
+        // `webhookConfig`
+        WebhookConfig webhookConfig;
+        final String repo_org = "Samsung";
+        final String repo_name = "LPVS";
+        final String commit_sha = "895337e89ae103ff2d18c9e0d93709f743226afa";
+        final String repository_url = "https://github.com/Samsung/LPVS";
+
+        // `lpvs_file_1`
+        LPVSFile lpvs_file_1;
+        final String file_url_1 = "https://github.com/Samsung/LPVS/tree/main/src/main/java/com/lpvs/service/GitHubService.java";
+        final String file_path_1 = "src/main/java/com/lpvs/service/GitHubService.java";
+        final String snippet_match_1 = "/**\n" +
+                " * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.\n" +
+                " *\n" +
+                " * Use of this source code is governed by a MIT license that can be\n" +
+                " * found in the LICENSE file.\n" +
+                " */\n";
+        final String matched_lines_1 = "1-6";
+        final String component_1 = "LPVS::Services";
+
+        // `lpvs_license_1`
+        LPVSLicense lpvs_license_1;
+        final String license_name_1 = "MIT License";
+        final String spdx_id_1 = "MIT";
+        final String access_1 = "PERMITTED";
+        final String checklist_url_1 = "https://opensource.org/licenses/MIT";
+
+        final String expected_comment = "**\\[Open Source License Validation\\]**  No license issue detected \n\n" +
+                "**Detected licenses:**\n\n\n" +
+                "**File:** src/main/java/com/lpvs/service/GitHubService.java\n" +
+                "**License(s):** <a target=\"_blank\" href=\"https://opensource.org/licenses/MIT\">MIT</a> (permitted)\n" +
+                "**Component:** LPVS::Services (https://github.com/Samsung/LPVS/tree/main/src/main/java/com/lpvs/service/GitHubService.java)\n" +
+                "**Matched Lines:** <a target=\"_blank\" href=\"https://github.com/Samsung/LPVS/blob/895337e89ae103ff2d18c9e0d93709f743226afa/src/main/java/com/lpvs/service/GitHubService.java#L1L6\">1-6</a>\n" +
+                "**Snippet Match:** /**\n" +
+                " * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.\n" +
+                " *\n" +
+                " * Use of this source code is governed by a MIT license that can be\n" +
+                " * found in the LICENSE file.\n" +
+                " */\n\n\n\n\n\n";
+
+        @BeforeEach
+        void setUp() {
+            // set `private static GitHub gitHub;` value
+            try {
+                Field staticPrivateGithub = GitHubService.class.getDeclaredField("gitHub");
+                staticPrivateGithub.setAccessible(true);
+                staticPrivateGithub.set(null, mocked_instance_gh);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                LOG.error("TestCommentResults__ProhibitedAbsentConflictsAbsent.setUp() error " + e);
+                fail();
+            }
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryName(repo_name);
+            webhookConfig.setRepositoryOrganization(repo_org);
+            webhookConfig.setPullRequestAPIUrl(url_pr_2);
+            webhookConfig.setHeadCommitSHA(commit_sha);
+            webhookConfig.setRepositoryUrl(repository_url);
+
+            try {
+                when(mocked_instance_gh.getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName())).thenReturn(mocked_repo);
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getRepository error " + e);
+            }
+            try {
+                mocked_pr_1 = new GHPullRequestOurMock(new URL(url_pr_1), null, null, -1, null);
+                mocked_pr_2 = new GHPullRequestOurMock(new URL(url_pr_2), null, null, -1, null);
+            } catch (MalformedURLException e) {
+                LOG.error("TestCommentResults__ProhibitedAbsentConflictsAbsent.setUp() error " + e);
+                fail();
+            }
+            try {
+                when(mocked_repo.getPullRequests(GHIssueState.OPEN)).thenReturn(Arrays.asList(mocked_pr_1, mocked_pr_2));
+            } catch (IOException e) {
+                LOG.error("mocked_repo.getPullRequests error " + e);
+            }
+
+            lpvs_license_1 = new LPVSLicense(1L, license_name_1, spdx_id_1, access_1, checklist_url_1, List.of());
+            lpvs_file_1 = new LPVSFile(1L, file_url_1, file_path_1, snippet_match_1, matched_lines_1, Set.of(lpvs_license_1), component_1);
+        }
+
+        @Test
+        public void testCommentResults__ProhibitedAbsentConflictsAbsent() {
+            // main test
+            gh_service.commentResults(webhookConfig, List.of(lpvs_file_1), List.of());
+
+            // `mocked_instance_gh` verify
+            try {
+                verify(mocked_instance_gh, times(1)).getRepository(webhookConfig.getRepositoryOrganization() + "/" + webhookConfig.getRepositoryName());
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__ProhibitedAbsentConflictsAbsent.testCommentResults__ProhibitedAbsentConflictsAbsent() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_instance_gh);
+
+            // `mocked_repo` verify
+            try {
+                verify(mocked_repo, times(1)).getPullRequests(GHIssueState.OPEN);
+                verify(mocked_repo, times(1)).createCommitStatus(commit_sha, GHCommitState.SUCCESS, null,
+                        "No license issue detected", "[Open Source License Validation]");
+            } catch (IOException e) {
+                LOG.error("TestCommentResults__ProhibitedAbsentConflictsAbsent.testCommentResults__ProhibitedAbsentConflictsAbsent() error " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(mocked_repo);
+
+            // `mocked_pr_2` verify
+            ((GHPullRequestOurMock)mocked_pr_2).verifyCommentCall(expected_comment);
+            ((GHPullRequestOurMock)mocked_pr_2).verifyNoMoreCommentCalls();
+        }
+    }
+
+    @Nested
     class TestGetRepositoryLicense__ApiUrlAbsentLisencePresent {
 
         final String GH_LOGIN = "test_login";
@@ -1422,6 +1921,70 @@ public class GitHubServiceTest {
                 mocked_static_gh.verifyNoMoreInteractions();
 
             }
+        }
+    }
+
+    @Nested
+    class TestGetMatchedLinesAsLink_NotAll {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+
+        // `webhookConfig`
+        WebhookConfig webhookConfig;
+        final String commit_sha = "895337e89ae103ff2d18c9e0d93709f743226afa";
+        final String repository_url = "https://github.com/Samsung/LPVS";
+
+        // `lpvs_file_1`
+        LPVSFile lpvs_file_1;
+        final String file_path_1 = "src/main/java/com/lpvs/service/GitHubService.java";
+        final String matched_lines_1 = "1-6";
+
+        final String expected_result = "<a target=\"_blank\" href=\"https://github.com/Samsung/LPVS/blob/895337e89ae103ff2d18c9e0d93709f743226afa/src/main/java/com/lpvs/service/GitHubService.java#L1L6\">1-6</a>";
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setHeadCommitSHA(commit_sha);
+            webhookConfig.setRepositoryUrl(repository_url);
+
+            lpvs_file_1 = new LPVSFile(1L, null, file_path_1, null, matched_lines_1, null, null);
+        }
+
+        @Test
+        public void testGetMatchedLinesAsLink_NotAll() {
+            // main test
+            assertEquals(expected_result, gh_service.getMatchedLinesAsLink(webhookConfig, lpvs_file_1));
+        }
+    }
+
+    @Nested
+    class TestGetMatchedLinesAsLink_All {
+        final GitHubService gh_service = new GitHubService(null, null, null);
+
+        // `webhookConfig`
+        WebhookConfig webhookConfig;
+        final String commit_sha = "895337e89ae103ff2d18c9e0d93709f743226afa";
+        final String repository_url = "https://github.com/Samsung/LPVS";
+
+        // `lpvs_file_1`
+        LPVSFile lpvs_file_1;
+        final String file_path_1 = "LICENSE";
+        final String matched_lines_1 = "all";
+
+        final String expected_result = "<a target=\"_blank\" href=\"https://github.com/Samsung/LPVS/blob/895337e89ae103ff2d18c9e0d93709f743226afa/LICENSE\">all</a>";
+
+        @BeforeEach
+        void setUp() {
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setHeadCommitSHA(commit_sha);
+            webhookConfig.setRepositoryUrl(repository_url);
+
+            lpvs_file_1 = new LPVSFile(1L, null, file_path_1, null, matched_lines_1, null, null);
+        }
+
+        @Test
+        public void testGetMatchedLinesAsLink_All() {
+            // main test
+            assertEquals(expected_result, gh_service.getMatchedLinesAsLink(webhookConfig, lpvs_file_1));
         }
     }
 }

--- a/src/test/java/com/lpvs/service/GitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/GitHubServiceTest.java
@@ -92,7 +92,7 @@ public class GitHubServiceTest {
                 this.arg = arg;
             }
         }
-        
+
         private final List<CommentCall> comment_calls = new ArrayList<>();
 
         @Override
@@ -122,7 +122,6 @@ public class GitHubServiceTest {
                 }
             }
         }
-
     }
 
     @Nested
@@ -1451,8 +1450,8 @@ public class GitHubServiceTest {
             verifyNoMoreInteractions(mocked_repo);
 
             // `mocked_pr_2` verify
-            ((GHPullRequestOurMock)mocked_pr_2).verifyCommentCall(expected_comment);
-            ((GHPullRequestOurMock)mocked_pr_2).verifyNoMoreCommentCalls();
+            ((GHPullRequestOurMock) mocked_pr_2).verifyCommentCall(expected_comment);
+            ((GHPullRequestOurMock) mocked_pr_2).verifyNoMoreCommentCalls();
         }
     }
 
@@ -1573,8 +1572,8 @@ public class GitHubServiceTest {
             verifyNoMoreInteractions(mocked_repo);
 
             // `mocked_pr_2` verify
-            ((GHPullRequestOurMock)mocked_pr_2).verifyCommentCall(expected_comment);
-            ((GHPullRequestOurMock)mocked_pr_2).verifyNoMoreCommentCalls();
+            ((GHPullRequestOurMock) mocked_pr_2).verifyCommentCall(expected_comment);
+            ((GHPullRequestOurMock) mocked_pr_2).verifyNoMoreCommentCalls();
         }
     }
 


### PR DESCRIPTION
# Description

Added unit test set for the com.lpvs.service.GithubService class. This step is required for the GitHub action infra setup.

## Type of change

Please delete options that are not relevant.

- [x] Code cleanup/refactoring
- [x] Test Coverage update

# How Has This Been Tested?
mvn clean install
mvn test

**Test Configuration**:
* Java: v18
* LPVS Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes