### PR TITLE
`DetectService` and `ResponseWrapper` tests

### DIFF
--- a/src/main/java/com/lpvs/service/DetectService.java
+++ b/src/main/java/com/lpvs/service/DetectService.java
@@ -22,11 +22,16 @@ import java.util.List;
 @Service
 public class DetectService {
 
-    @Value("${scanner:scanoss}")
     private String scannerType;
 
-    @Autowired
     private ScanossDetectService scanossDetectService;
+
+    @Autowired
+    public DetectService(@Value("${scanner:scanoss}") String scannerType,
+                         ScanossDetectService scanossDetectService) {
+        this.scannerType = scannerType;
+        this.scanossDetectService = scanossDetectService;
+    }
 
     private static Logger LOG = LoggerFactory.getLogger(DetectService.class);
 

--- a/src/test/java/com/lpvs/entity/ResponseWrapperTest.java
+++ b/src/test/java/com/lpvs/entity/ResponseWrapperTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.lpvs.entity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ResponseWrapperTest {
+    private static Logger LOG = LoggerFactory.getLogger(ResponseWrapperTest.class);
+
+    final String test_value = "test_value";
+    ResponseWrapper responseWrapper;
+
+    @Test
+    public void testResponseWrapperConstructor() {
+        responseWrapper = new ResponseWrapper(test_value);
+
+        String actual;
+        try {
+            Field message_field = responseWrapper.getClass().getDeclaredField("message");
+            message_field.setAccessible(true);
+            actual = (String) message_field.get(responseWrapper);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            LOG.error("Java reflect exception at ResponseWrapperTest: " + e);
+            fail();
+
+            throw new RuntimeException();  // to get rid of "`actual` may be unassigned" warning
+        }
+
+        Assertions.assertEquals(test_value, actual);
+    }
+}

--- a/src/test/java/com/lpvs/service/DetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/DetectServiceTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.lpvs.service;
+
+import com.lpvs.entity.LPVSFile;
+import com.lpvs.entity.config.WebhookConfig;
+import com.lpvs.service.scanner.scanoss.ScanossDetectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+
+public class DetectServiceTest {
+    private static Logger LOG = LoggerFactory.getLogger(DetectServiceTest.class);
+
+    @Nested
+    class TestInit {
+        final DetectService detectService = new DetectService("scanoss", null);
+
+        @Test
+        public void testInit() {
+            try {
+                Method init_method = detectService.getClass().getDeclaredMethod("init");
+                init_method.setAccessible(true);
+                init_method.invoke(detectService);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                LOG.error("DetectServiceTest::TestInit exception: " + e);
+                fail();
+            }
+        }
+    }
+
+    @Nested
+    class TestRunScan__Scanoss {
+        DetectService detectService;
+        ScanossDetectService scanoss_mock = mock(ScanossDetectService.class);
+        WebhookConfig webhookConfig;
+        final String test_path = "test_path";
+
+        LPVSFile lpvs_file_1, lpvs_file_2;
+
+        @BeforeEach
+        void setUp() {
+            detectService = new DetectService("scanoss", scanoss_mock);
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryId(1L);
+
+            lpvs_file_1 = new LPVSFile(1L, null, null, null, null, null, null);
+            lpvs_file_2 = new LPVSFile(2L, null, null, null, null, null, null);
+
+            when(scanoss_mock.checkLicenses(webhookConfig)).thenReturn(List.of(lpvs_file_1, lpvs_file_2));
+        }
+
+        @Test
+        public void testRunScan__Scanoss() {
+            try {
+                // main test
+                assertEquals(List.of(lpvs_file_1, lpvs_file_2), detectService.runScan(webhookConfig, test_path));
+            } catch (Exception e) {
+                LOG.error("DetectServiceTest::TestRunScan__Scanoss exception: " + e);
+                fail();
+            }
+
+            // verify `scanoss_mock`
+            try {
+                verify(scanoss_mock, times(1)).runScan(webhookConfig, test_path);
+            } catch (Exception e) {
+                LOG.error("DetectServiceTest::TestRunScan__Scanoss exception: " + e);
+                fail();
+            }
+            verify(scanoss_mock, times(1)).checkLicenses(webhookConfig);
+            verifyNoMoreInteractions(scanoss_mock);
+        }
+    }
+
+    @Nested
+    class TestRunScan__ScanossException {
+        DetectService detectService;
+        ScanossDetectService scanoss_mock = mock(ScanossDetectService.class);
+        WebhookConfig webhookConfig;
+        final String test_path = "test_path";
+        final String exc_msg = "Test exception for TestRunScan__ScanossException. Normal behavior.";
+
+        @BeforeEach
+        void setUp() {
+            detectService = new DetectService("scanoss", scanoss_mock);
+
+            webhookConfig = new WebhookConfig();
+            webhookConfig.setRepositoryId(1L);
+
+            try {
+                doThrow(new Exception(exc_msg))
+                        .when(scanoss_mock)
+                        .runScan(webhookConfig, test_path);
+            } catch (Exception e) {
+                LOG.error("DetectServiceTest::TestRunScan__ScanossException exception: " + e);
+                fail();
+            }
+        }
+
+        @Test
+        public void testRunScan__ScanossException() {
+            try {
+                // main test
+                detectService.runScan(webhookConfig, test_path);
+                fail("Should exit by exception");
+            } catch (Exception e) {
+                if (!e.getMessage().equals(exc_msg)) {
+                    fail("Another exception caught: " + e);
+                }
+                // test pass
+            }
+
+            // verify `scanoss_mock`
+            try {
+                verify(scanoss_mock, times(1)).runScan(webhookConfig, test_path);
+            } catch (Exception e) {
+                LOG.error("DetectServiceTest::TestRunScan__ScanossException exception: " + e);
+                fail();
+            }
+            verifyNoMoreInteractions(scanoss_mock);
+        }
+    }
+
+    @Nested
+    class TestRunScan__NotScanoss {
+        DetectService detectService;
+
+        @BeforeEach
+        void setUp() {
+            detectService = new DetectService("not_scanoss", null);
+        }
+
+        @Test
+        public void testRunScan__NotScanoss() {
+            // main test
+            try {
+                assertEquals(new ArrayList<>(), detectService.runScan(null, null));
+            } catch (Exception e) {
+                LOG.error("DetectServiceTest::TestRunScan__NotScanoss exception: " + e);
+                fail();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Added unit test set for the `com.lpvs.service.DetectService` and `com.lpvs.entity.ResponseWrapper` classes. This step is required for the GitHub action infra setup.

## Type of change

- [x] Code cleanup/refactoring
- [x] Test Coverage update

# How Has This Been Tested?
mvn clean install
mvn test

**Test Configuration**:
* Java: v18
* LPVS Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes