### PR TITLE
Fix `unchecked cast` warning

### DIFF
--- a/src/test/java/com/lpvs/service/LicenseServiceTest.java
+++ b/src/test/java/com/lpvs/service/LicenseServiceTest.java
@@ -148,8 +148,7 @@ public class LicenseServiceTest {
 
             Field conflicts_field = licenseService.getClass().getDeclaredField("licenseConflicts");
             conflicts_field.setAccessible(true);
-            List<LicenseService.Conflict<String, String>> conflicts_list
-                    = (List<LicenseService.Conflict<String, String>>) conflicts_field.get(licenseService);
+            List<?> conflicts_list = (List<?>) conflicts_field.get(licenseService);
 
             assertEquals(List.of(conflict_1, conflict_2), conflicts_list);
         }


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

The warning below is fixed.
```bash
[INFO] --- maven-compiler-plugin:3.10.1:testCompile (default-testCompile) @ lpvs ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 15 source files to /home/t25kim/work/LPVS/target/test-classes
[WARNING] /home/t25kim/work/LPVS/src/test/java/com/lpvs/service/LicenseServiceTest.java:[152,90] unchecked cast
  required: java.util.List<com.lpvs.service.LicenseService.Conflict<java.lang.String,java.lang.String>>
  found:    java.lang.Object
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
mvn test
```

**Test Configuration**:
* Java: v11
* LPVS Release: v1.0.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
