### PR TITLE
Remove lgtm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 
 ![License Pre-Validation Service (LPVS)](lpvslogo.png)
 [![Build](https://github.com/samsung/lpvs/workflows/Build/badge.svg)](https://github.com/samsung/lpvs/actions?query=workflow%3ABuild)
-[![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/Samsung/LPVS.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Samsung/LPVS/context:java)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7127523.svg)](https://doi.org/10.5281/zenodo.7127523)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/Samsung/LPVS.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Samsung/LPVS/alerts/)
 [![CodeQL Analysis](https://github.com/Samsung/LPVS/workflows/CodeQL%20Analysis/badge.svg)](https://github.com/Samsung/LPVS/actions?query=workflow%3A%22CodeQL+Analysis%22)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6309/badge)](https://bestpractices.coreinfrastructure.org/projects/6309)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Samsung/LPVS/badge)](https://api.securityscorecards.dev/projects/github.com/Samsung/LPVS)


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Removed the LGTM badges as they are no longer supported from December 16th. 

## Type of change

- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
