### PR TITLE
Fix the errors of duplicate and non-existent keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3.4'
 services:
 
   lpvs:
-    environment:
-      WAIT_HOSTS: mysqldb:3306
     build:
       context: .
     restart: always
@@ -33,9 +31,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
     healthcheck:
-        test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
-        timeout: 20s
-        retries: 10
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
     volumes:
       - ./mysql-lpvs-data:/var/lib/mysql # db storage
       - ./src/main/resources/database_dump.sql:/docker-entrypoint-initdb.d/init.sql # init for creating db lpvs with predifined tables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       - github.api.url=https://api.github.com  # for usual GitHub account 
       - github.secret=LPVS 
     depends_on:
-      - mysqldb
+      mysqldb:
+        condition: service_healthy
     networks:
       - lpvs
       


### PR DESCRIPTION
# Description

Duplicate Key : environment
Non-existent Key : WAIT_HOSTS

**Error log of the duplicate key, environment**
```
$ docker compose up
yaml: unmarshal errors:
  line 13: mapping key "environment" already defined at line 6
```

**Error log of the non-existent key, WAIT_HOSTS**
```
$ docker compose up
yaml: line 11: did not find expected key
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
$ docker compose up

**Test Configuration**:
* Java: v11
* LPVS Release: v1.0.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
