### PR TITLE
Add Github OAuth feature to backend application

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,20 +10,33 @@ services:
     ports:
       - "7896:7896"
     environment:
-#      - frontend.main-page.url=http://localhost:3000
-#      - cors.allowed-origin=http://localhost:3000
+      ## Required if frontend and backend are different
+      #- frontend.main-page.url=http://localhost:3000
+      #- cors.allowed-origin=http://localhost:3000
+      ## Database Configuration
       - spring.datasource.url=jdbc:mysql://mysqldb:3306/lpvs
       - spring.datasource.username=root
       - spring.datasource.password=
-      ## github data
+      ## Github data for fetching code
       - github.login=
       - github.token=
       - github.api.url=https://api.github.com 
       - github.secret=LPVS
+      ## Google OAuth Login
       - spring.security.oauth2.client.registration.google.client-id=GOOGLE_CLIENT_ID
       - spring.security.oauth2.client.registration.google.client-secret=GOOGLE_CLIENT_SECRET
       - spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:7896/login/oauth2/code/google
       - spring.security.oauth2.client.registration.google.scope=profile, email
+      ## Github OAuth Login
+      - spring.security.oauth2.client.registration.github.client-id=GITHUB_CLIENT_ID
+      - spring.security.oauth2.client.registration.github.client-secret=GITHUB_CLIENT_SECRET
+      - spring.security.oauth2.client.registration.github.redirect-uri=http://localhost:7896/login/oauth2/code/github
+      - spring.security.oauth2.client.registration.github.scope=user
+      ## Github Enterprise Configuration if necessary
+      #- spring.security.oauth2.client.provider.github.authorization-uri=https://HOSTNAME/login/oauth/authorize
+      #- spring.security.oauth2.client.provider.github.token-uri=https://HOSTNAME/login/oauth/access_token
+      #- spring.security.oauth2.client.provider.github.user-info-uri=https://HOSTNAME/api/v3/user
+
     depends_on:
       mysqldb:
         condition: service_healthy

--- a/src/main/java/com/lpvs/auth/OAuthAttributes.java
+++ b/src/main/java/com/lpvs/auth/OAuthAttributes.java
@@ -36,6 +36,15 @@ public enum OAuthAttributes {
         memberProfile.setName((String) kakaoProfile.get("nickname"));
         memberProfile.setEmail((String) kakaoAccount.get("email"));
         return memberProfile;
+    }),
+
+    GITHUB("github", (attributes) -> {
+        MemberProfile memberProfile = new MemberProfile();
+        memberProfile.setName((String) attributes.get("name"));
+        // TODO: The email from Github can be null, so place the login value for a while.
+        //       Changing unique key from the member table is required.
+        memberProfile.setEmail((String) attributes.get("login"));
+        return memberProfile;
     });
 
     private final String registrationId;


### PR DESCRIPTION
# Description

It is intended to login with Github or Github Enterprise account.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
1. Creating an OAuth app from Github is required. see the [official doc](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app).
2. Place the necessary values to the properties, `client-id` and `client-secret`, in docker-compose.yml file.
3. Build with `docker compose build` and run the lpvs container with `docker compose up`
4. Go to `http://localhost:7896/login` on the web browser and choose `Github`.

**Test Configuration**:
* Java: v11
* LPVS Release: v1.x.x

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
