### PR TITLE
feat: Add missing unit-tests for `entities` and `enums`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+src/main/resources/.idea/*
 .idea/*
 target/
 Projects/
@@ -29,3 +30,6 @@ Projects/
 
 # DB storage by default
 mysql-lpvs-data/
+
+# Run results
+RESULTS/

--- a/src/test/java/com/lpvs/entity/LPVSDetectedLicenseTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSDetectedLicenseTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+package com.lpvs.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LPVSDetectedLicenseTest {
+
+    LPVSDetectedLicense detectedLicense;
+
+    @BeforeEach
+    void setUp() {
+        detectedLicense = new LPVSDetectedLicense();
+        detectedLicense.setId(1L);
+        detectedLicense.setFilePath("sample/file/path");
+        detectedLicense.setType("sampleType");
+        detectedLicense.setMatch("sampleMatch");
+        detectedLicense.setLines("sampleLines");
+        detectedLicense.setComponentFilePath("sampleComponentFilePath");
+        detectedLicense.setComponentFileUrl("sampleComponentFileUrl");
+        detectedLicense.setComponentName("sampleComponentName");
+        detectedLicense.setComponentLines("sampleComponentLines");
+        detectedLicense.setComponentUrl("sampleComponentUrl");
+        detectedLicense.setComponentVersion("sampleComponentVersion");
+        detectedLicense.setComponentVendor("sampleComponentVendor");
+        detectedLicense.setIssue(true);
+    }
+
+    @Test
+    public void getterSetterIdTest() {
+        assertEquals(detectedLicense.getId(), 1L);
+        detectedLicense.setId(2L);
+        assertNotEquals(detectedLicense.getId(), 1L);
+        assertEquals(detectedLicense.getId(), 2L);
+    }
+
+    @Test
+    public void constructorAndGettersTest() {
+        assertEquals(1L, detectedLicense.getId());
+        assertEquals("sample/file/path", detectedLicense.getFilePath());
+        assertEquals("sampleType", detectedLicense.getType());
+        assertEquals("sampleMatch", detectedLicense.getMatch());
+        assertEquals("sampleLines", detectedLicense.getLines());
+        assertEquals("sampleComponentFilePath", detectedLicense.getComponentFilePath());
+        assertEquals("sampleComponentFileUrl", detectedLicense.getComponentFileUrl());
+        assertEquals("sampleComponentName", detectedLicense.getComponentName());
+        assertEquals("sampleComponentLines", detectedLicense.getComponentLines());
+        assertEquals("sampleComponentUrl", detectedLicense.getComponentUrl());
+        assertEquals("sampleComponentVersion", detectedLicense.getComponentVersion());
+        assertEquals("sampleComponentVendor", detectedLicense.getComponentVendor());
+        assertEquals(true, detectedLicense.getIssue());
+    }
+
+    @Test
+    public void setFilePathTest() {
+        final String newFilePath = "newFilePath";
+        assertEquals("sample/file/path", detectedLicense.getFilePath());
+        detectedLicense.setFilePath(newFilePath);
+        assertNotEquals("sample/file/path", detectedLicense.getFilePath());
+        assertEquals(newFilePath, detectedLicense.getFilePath());
+    }
+
+    @Test
+    public void setTypeTest() {
+        final String newType = "newType";
+        assertEquals("sampleType", detectedLicense.getType());
+        detectedLicense.setType(newType);
+        assertNotEquals("sampleType", detectedLicense.getType());
+        assertEquals(newType, detectedLicense.getType());
+    }
+
+    @Test
+    public void setMatchTest() {
+        final String newMatch = "newMatch";
+        assertEquals("sampleMatch", detectedLicense.getMatch());
+        detectedLicense.setMatch(newMatch);
+        assertNotEquals("sampleMatch", detectedLicense.getMatch());
+        assertEquals(newMatch, detectedLicense.getMatch());
+    }
+
+    @Test
+    public void setLinesTest() {
+        final String newLines = "newLines";
+        assertEquals("sampleLines", detectedLicense.getLines());
+        detectedLicense.setLines(newLines);
+        assertNotEquals("sampleLines", detectedLicense.getLines());
+        assertEquals(newLines, detectedLicense.getLines());
+    }
+
+    @Test
+    public void setComponentFilePathTest() {
+        final String newComponentFilePath = "newComponentFilePath";
+        assertEquals("sampleComponentFilePath", detectedLicense.getComponentFilePath());
+        detectedLicense.setComponentFilePath(newComponentFilePath);
+        assertNotEquals("sampleComponentFilePath", detectedLicense.getComponentFilePath());
+        assertEquals(newComponentFilePath, detectedLicense.getComponentFilePath());
+    }
+
+    @Test
+    public void setComponentFileUrlTest() {
+        final String newComponentFileUrl = "newComponentFileUrl";
+        assertEquals("sampleComponentFileUrl", detectedLicense.getComponentFileUrl());
+        detectedLicense.setComponentFileUrl(newComponentFileUrl);
+        assertNotEquals("sampleComponentFileUrl", detectedLicense.getComponentFileUrl());
+        assertEquals(newComponentFileUrl, detectedLicense.getComponentFileUrl());
+    }
+
+    @Test
+    public void setComponentNameTest() {
+        final String newComponentName = "newComponentName";
+        assertEquals("sampleComponentName", detectedLicense.getComponentName());
+        detectedLicense.setComponentName(newComponentName);
+        assertNotEquals("sampleComponentName", detectedLicense.getComponentName());
+        assertEquals(newComponentName, detectedLicense.getComponentName());
+    }
+
+    @Test
+    public void setComponentLinesTest() {
+        final String newComponentLines = "newComponentLines";
+        assertEquals("sampleComponentLines", detectedLicense.getComponentLines());
+        detectedLicense.setComponentLines(newComponentLines);
+        assertNotEquals("sampleComponentLines", detectedLicense.getComponentLines());
+        assertEquals(newComponentLines, detectedLicense.getComponentLines());
+    }
+
+    @Test
+    public void setComponentUrlTest() {
+        final String newComponentUrl = "newComponentUrl";
+        assertEquals("sampleComponentUrl", detectedLicense.getComponentUrl());
+        detectedLicense.setComponentUrl(newComponentUrl);
+        assertNotEquals("sampleComponentUrl", detectedLicense.getComponentUrl());
+        assertEquals(newComponentUrl, detectedLicense.getComponentUrl());
+    }
+
+    @Test
+    public void setComponentVersionTest() {
+        final String newComponentVersion = "newComponentVersion";
+        assertEquals("sampleComponentVersion", detectedLicense.getComponentVersion());
+        detectedLicense.setComponentVersion(newComponentVersion);
+        assertNotEquals("sampleComponentVersion", detectedLicense.getComponentVersion());
+        assertEquals(newComponentVersion, detectedLicense.getComponentVersion());
+    }
+
+    @Test
+    public void setComponentVendorTest() {
+        final String newComponentVendor = "newComponentVendor";
+        assertEquals("sampleComponentVendor", detectedLicense.getComponentVendor());
+        detectedLicense.setComponentVendor(newComponentVendor);
+        assertNotEquals("sampleComponentVendor", detectedLicense.getComponentVendor());
+        assertEquals(newComponentVendor, detectedLicense.getComponentVendor());
+    }
+
+    @Test
+    public void setIssueTest() {
+        final boolean newIssue = false;
+        assertEquals(true, detectedLicense.getIssue());
+        detectedLicense.setIssue(newIssue);
+        assertNotEquals(true, detectedLicense.getIssue());
+        assertEquals(newIssue, detectedLicense.getIssue());
+    }
+
+    @Test
+    public void setPullRequestTest() {
+        LPVSPullRequest pullRequest = new LPVSPullRequest();
+        assertNull(detectedLicense.getPullRequest());
+        detectedLicense.setPullRequest(pullRequest);
+        assertNotNull(detectedLicense.getPullRequest());
+    }
+
+    @Test
+    public void setLicenseTest() {
+        LPVSLicense license = new LPVSLicense();
+        assertNull(detectedLicense.getLicense());
+        detectedLicense.setLicense(license);
+        assertNotNull(detectedLicense.getLicense());
+    }
+
+    @Test
+    public void setLicenseConflictTest() {
+        LPVSLicenseConflict licenseConflict = new LPVSLicenseConflict();
+        assertNull(detectedLicense.getLicenseConflict());
+        detectedLicense.setLicenseConflict(licenseConflict);
+        assertNotNull(detectedLicense.getLicenseConflict());
+    }
+}

--- a/src/test/java/com/lpvs/entity/LPVSDiffFileTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSDiffFileTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+package com.lpvs.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class LPVSDiffFileTest {
+
+    @Test
+    public void testAppendPatchedLine() {
+        LPVSDiffFile diffFile = new LPVSDiffFile();
+        String line1 = "Line 1";
+        String line2 = "Line 2";
+        diffFile.appendPatchedLine(line1);
+        diffFile.appendPatchedLine(line2);
+        List<String> changedLines = diffFile.getChangedLines();
+        assertNotNull(changedLines);
+        assertEquals(2, changedLines.size());
+        assertEquals(line1, changedLines.get(0));
+        assertEquals(line2, changedLines.get(1));
+    }
+
+    @Test
+    public void testAppendPatchedLineWithNullChangedLines() {
+        LPVSDiffFile diffFile = new LPVSDiffFile();
+        String line = "Line 1";
+        diffFile.appendPatchedLine(line);
+        List<String> changedLines = diffFile.getChangedLines();
+        assertNotNull(changedLines);
+        assertEquals(1, changedLines.size());
+        assertEquals(line, changedLines.get(0));
+    }
+
+    @Test
+    public void testAppendPatchedLineWithEmptyChangedLines() {
+        LPVSDiffFile diffFile = new LPVSDiffFile();
+        diffFile.setChangedLines(new LinkedList<>());
+        String line = "Line 1";
+        diffFile.appendPatchedLine(line);
+        List<String> changedLines = diffFile.getChangedLines();
+        assertNotNull(changedLines);
+        assertEquals(1, changedLines.size());
+        assertEquals(line, changedLines.get(0));
+    }
+}

--- a/src/test/java/com/lpvs/entity/LPVSLoginMemberTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSLoginMemberTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+package com.lpvs.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LPVSLoginMemberTest {
+
+    @Test
+    public void testLPVSLoginMemberConstructor() {
+        Boolean isLoggedIn = true;
+        LPVSMember member = new LPVSMember(1L, "John", "john@example.com", "provider", "nickname");
+        LPVSLoginMember loginMember = new LPVSLoginMember(isLoggedIn, member);
+        assertEquals(isLoggedIn, loginMember.getIsLoggedIn());
+        assertEquals(member, loginMember.getMember());
+    }
+
+    @Test
+    public void testLPVSLoginMemberGettersAndSetters() {
+        LPVSLoginMember loginMember = new LPVSLoginMember(false, new LPVSMember(1L, "John", "john@email.com", "provider", "nickname"));
+        loginMember.setIsLoggedIn(true);
+        LPVSMember newMember = new LPVSMember(1L, "John", "john@email.com", "provider", "nickname");
+        loginMember.setMember(newMember);
+        assertTrue(loginMember.getIsLoggedIn());
+        assertEquals(newMember, loginMember.getMember());
+    }
+}

--- a/src/test/java/com/lpvs/entity/LPVSMemberTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSMemberTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+package com.lpvs.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LPVSMemberTest {
+
+    @Test
+    public void testLPVSMemberConstructor() {
+        Long id = 1L;
+        String name = "John Doe";
+        String email = "john@example.com";
+        String provider = "GitHub";
+        String nickname = "johndoe";
+
+        LPVSMember member = LPVSMember.builder()
+                .id(id)
+                .name(name)
+                .email(email)
+                .provider(provider)
+                .nickname(nickname)
+                .build();
+
+        assertEquals(id, member.getId());
+        assertEquals(name, member.getName());
+        assertEquals(email, member.getEmail());
+        assertEquals(provider, member.getProvider());
+        assertEquals(nickname, member.getNickname());
+    }
+
+    @Test
+    public void testLPVSMemberUpdate() {
+        LPVSMember member = LPVSMember.builder()
+                .id(1L)
+                .name("Alice Johnson")
+                .email("alice@example.com")
+                .provider("GitHub")
+                .nickname("alicej")
+                .build();
+
+        member.update("Bob Smith", "bob@example.com");
+        assertEquals("Bob Smith", member.getName());
+        assertEquals("bob@example.com", member.getEmail());
+    }
+
+    @Test
+    public void testSetNickname() {
+        LPVSMember member = LPVSMember.builder()
+                .id(1L)
+                .name("Charlie Brown")
+                .email("charlie@example.com")
+                .provider("GitHub")
+                .nickname("charlieb")
+                .build();
+
+        member.setNickname("charliebrown");
+        assertEquals("charliebrown", member.getNickname());
+    }
+
+    @Test
+    public void testSetOrganization() {
+        LPVSMember member = LPVSMember.builder()
+                .id(1L)
+                .name("David Smith")
+                .email("david@example.com")
+                .provider("GitHub")
+                .nickname("charlieb")
+                .build();
+
+        member.setOrganization("Org");
+        assertEquals("Org", member.getOrganization());
+    }
+}

--- a/src/test/java/com/lpvs/entity/enums/LPVSPullRequestActionTest.java
+++ b/src/test/java/com/lpvs/entity/enums/LPVSPullRequestActionTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
- * <p>
+ *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.
  */

--- a/src/test/java/com/lpvs/entity/enums/LPVSPullRequestStatusTest.java
+++ b/src/test/java/com/lpvs/entity/enums/LPVSPullRequestStatusTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+package com.lpvs.entity.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LPVSPullRequestStatusTest {
+
+    @Test
+    public void testGetPullRequestStatus() {
+        assertEquals("Cannot access the pull request", LPVSPullRequestStatus.NO_ACCESS.getPullRequestStatus());
+        assertEquals("License issues detected", LPVSPullRequestStatus.ISSUES_DETECTED.getPullRequestStatus());
+        assertEquals("Error while posting results", LPVSPullRequestStatus.INTERNAL_ERROR.getPullRequestStatus());
+        assertEquals("Scan completed", LPVSPullRequestStatus.COMPLETED.getPullRequestStatus());
+        assertEquals("Scan is scheduled", LPVSPullRequestStatus.SCANNING.getPullRequestStatus());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("Cannot access the pull request", LPVSPullRequestStatus.NO_ACCESS.toString());
+        assertEquals("License issues detected", LPVSPullRequestStatus.ISSUES_DETECTED.toString());
+        assertEquals("Error while posting results", LPVSPullRequestStatus.INTERNAL_ERROR.toString());
+        assertEquals("Scan completed", LPVSPullRequestStatus.COMPLETED.toString());
+        assertEquals("Scan is scheduled", LPVSPullRequestStatus.SCANNING.toString());
+    }
+
+    @Test
+    public void testEnumValues() {
+        LPVSPullRequestStatus[] values = LPVSPullRequestStatus.values();
+        assertEquals(5, values.length);
+        assertEquals(LPVSPullRequestStatus.NO_ACCESS, values[0]);
+        assertEquals(LPVSPullRequestStatus.ISSUES_DETECTED, values[1]);
+        assertEquals(LPVSPullRequestStatus.INTERNAL_ERROR, values[2]);
+        assertEquals(LPVSPullRequestStatus.COMPLETED, values[3]);
+        assertEquals(LPVSPullRequestStatus.SCANNING, values[4]);
+    }
+}

--- a/src/test/java/com/lpvs/entity/enums/LPVSVcsTest.java
+++ b/src/test/java/com/lpvs/entity/enums/LPVSVcsTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+package com.lpvs.entity.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class LPVSVcsTest {
+
+    @Test
+    public void testGetVcs() {
+        assertEquals("github", LPVSVcs.GITHUB.getVcs());
+        assertEquals("swarm", LPVSVcs.SWARM.getVcs());
+        assertEquals("gerrit", LPVSVcs.GERRIT.getVcs());
+        assertEquals("gitlab", LPVSVcs.GITLAB.getVcs());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("github", LPVSVcs.GITHUB.toString());
+        assertEquals("swarm", LPVSVcs.SWARM.toString());
+        assertEquals("gerrit", LPVSVcs.GERRIT.toString());
+        assertEquals("gitlab", LPVSVcs.GITLAB.toString());
+    }
+
+    @Test
+    public void testConvertFrom() {
+        assertEquals(LPVSVcs.GITHUB, LPVSVcs.convertFrom("github"));
+        assertEquals(LPVSVcs.SWARM, LPVSVcs.convertFrom("swarm"));
+        assertEquals(LPVSVcs.GERRIT, LPVSVcs.convertFrom("gerrit"));
+        assertEquals(LPVSVcs.GITLAB, LPVSVcs.convertFrom("gitlab"));
+        assertNull(LPVSVcs.convertFrom("unknown"));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Oleg Kopysov <o.kopysov@samsung.com>

# Description

We have to cover more classes by unit tests to improve code coverage.
In this PR, missing `entity` and `enum` classes are covered by additional unit tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [X] Test Coverage update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
