### PR TITLE
docs: Enable Javadoc generation as GitHub action

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,42 @@
+name: Generate and Publish Javadoc
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate-and-publish-javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+
+      - name: Set up JDK
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Build and generate Javadoc
+        run: mvn clean package javadoc:javadoc
+
+      - name: Check if gh-pages branch exists
+        run: git show-ref --verify --quiet refs/heads/gh-pages
+
+      - name: Create gh-pages branch if it doesn't exist
+        run: |
+          if [ $? -ne 0 ]; then
+            git checkout --orphan gh-pages
+            git rm -rf .
+            git commit --allow-empty -m "Initial commit for gh-pages branch"
+            git push origin gh-pages
+          fi
+
+      - name: Copy Javadoc to gh-pages branch
+        run: |
+          cp -R target/site/apidocs/. docs/
+          git add -A
+          git commit -m "Update Javadoc"
+          git push origin gh-pages

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>License Pre-Validation Service (LPVS) Overview</title>
+</head>
+<body>
+
+<img src="https://github.com/Samsung/LPVS/raw/main/lpvslogo.png" alt="LPVS Logo" width=60%>
+
+<h1>Introduction</h1>
+
+<p>Open-source code refers to software that is freely available for use, study, modification, and distribution, subject to meeting the conditions of the corresponding license. Failure to comply with the license conditions can lead to legal disputes, financial liabilities, the requirement to disclose intellectual property, and reputational damage.</p>
+
+<p>In projects with numerous external dependencies, accurately tracking license obligations can be challenging. The risk of unintentional license violations, especially in collaborative projects, increases. The License Pre-Validation Service (LPVS) addresses these license-related risks by analyzing the project, identifying components and their licenses at every commit, and generating a list of potential issues communicated as comments on GitHub.</p>
+
+<p>LPVS assists developers and project teams in ensuring license compliance for their open-source code by providing insights into potential license violations and their implications.</p>
+
+<h2>Features</h2>
+
+<ul>
+    <li><strong>License Scanners:</strong> LPVS integrates with the <a href="https://www.scanoss.com">SCANOSS</a> license scanner for comprehensive license analysis, ensuring compliance with open-source license requirements.</li>
+    
+    <li><strong>GitHub Review System Integration:</strong> Seamless integration with GitHub review system, automatically generating comments to highlight potential license violations or issues.</li>
+    
+    <li><strong>Comprehensive Issue Description:</strong> LPVS provides detailed descriptions of possible license violations, including specific information on risky code locations and an overview of license-related issues.</li>
+    
+    <li><strong>Continuous Monitoring:</strong> Facilitates continuous monitoring of license-related risks throughout the development process by analyzing each commit for potential violations.</li>
+    
+    <li><strong>Risk Mitigation:</strong> Aims to mitigate license-related risks through early detection, identification of potential violations, and providing information to understand and address them.</li>
+</ul>
+
+<h2>License</h2>
+
+<p>The LPVS source code is distributed under the <a href="https://opensource.org/licenses/MIT">MIT</a> open source license.</p>
+
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
 
     <groupId>com.lpvs</groupId>
     <artifactId>lpvs</artifactId>
+    <name>LPVS</name>
     <version>1.2.0</version>
     <packaging>jar</packaging>
 
@@ -179,6 +180,15 @@
                             <version>1.12.0</version>
                         </plugin>
                     </plugins>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <overview>${basedir}/doc/overview.html</overview>
+                    <docTitle>${project.name} ${project.version} API</docTitle>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/lpvs/LicensePreValidationSystem.java
+++ b/src/main/java/com/lpvs/LicensePreValidationSystem.java
@@ -19,19 +19,39 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 import com.lpvs.util.LPVSExitHandler;
 
+/**
+ * The main class for the License Pre-Validation Service (LPVS) application.
+ * This class configures and launches the LPVS Spring Boot application.
+ */
 @SpringBootApplication(scanBasePackages = {"com.lpvs"})
 @EnableAutoConfiguration
 @EnableAsync
 public class LicensePreValidationSystem {
 
+    /**
+     * The core pool size for the asynchronous task executor.
+     */
     private final int corePoolSize;
 
+    /**
+     * The exit handler for handling application exits.
+     */
     private static LPVSExitHandler exitHandler;
 
+    /**
+     * Constructs a new LicensePreValidationSystem with the specified core pool size.
+     *
+     * @param corePoolSize The core pool size for the asynchronous task executor.
+     */
     public LicensePreValidationSystem(@Value("${lpvs.cores:8}") int corePoolSize) {
         this.corePoolSize = corePoolSize;
     }
 
+    /**
+     * The main entry point of the LPVS application.
+     *
+     * @param args The command-line arguments passed to the application.
+     */
     public static void main(String[] args) {
         try {
             ApplicationContext applicationContext =
@@ -43,6 +63,11 @@ public class LicensePreValidationSystem {
         }
     }
 
+    /**
+     * Configures and retrieves an asynchronous task executor bean.
+     *
+     * @return An asynchronous task executor bean.
+     */
     @Bean("threadPoolTaskExecutor")
     public TaskExecutor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -51,6 +76,11 @@ public class LicensePreValidationSystem {
         return executor;
     }
 
+    /**
+     * Handles the "/exit" endpoint to exit the application with the specified exit code.
+     *
+     * @param exitCode The exit code for the application.
+     */
     @GetMapping("/exit")
     public static void exit(int exitCode) {
         exitHandler.exit(exitCode);

--- a/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
+++ b/src/main/java/com/lpvs/controller/GitHubWebhooksController.java
@@ -15,7 +15,6 @@ import com.lpvs.util.LPVSWebhookUtil;
 import com.lpvs.entity.LPVSResponseWrapper;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.catalina.core.ApplicationContext;
 import org.apache.commons.codec.binary.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,20 +32,26 @@ import javax.annotation.PostConstruct;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+/**
+ * Controller class for handling GitHub webhook events.
+ * This class is responsible for processing GitHub webhook payloads and triggering relevant actions.
+ */
 @RestController
 @Slf4j
 public class GitHubWebhooksController {
 
+    /**
+     * The GitHub secret used for validating webhook payloads.
+     * It is set from the LPVS_GITHUB_SECRET environment variable or the application property.
+     */
     private String GITHUB_SECRET;
 
-    ApplicationContext applicationContext;
-
     /**
-     * Sets the GitHub secret from the LPVS_GITHUB_SECRET environment variable or the application property.
+     * Initializes the GitHub secret from the LPVS_GITHUB_SECRET environment variable or the application property.
      * Exits the application if the secret is not set.
      */
     @PostConstruct
-    public void setProps() {
+    public void initializeGitHubSecret() {
         this.GITHUB_SECRET =
                 Optional.ofNullable(this.GITHUB_SECRET)
                         .filter(s -> !s.isEmpty())
@@ -54,17 +59,29 @@ public class GitHubWebhooksController {
                                 Optional.ofNullable(System.getenv("LPVS_GITHUB_SECRET"))
                                         .orElse(""));
         if (this.GITHUB_SECRET.isEmpty()) {
-            log.error("LPVS_GITHUB_SECRET(github.secret) is not set.");
+            log.error("LPVS_GITHUB_SECRET (github.secret) is not set.");
             exitHandler.exit(-1);
         }
     }
 
+    /**
+     * LPVSQueueService for handling user-related business logic.
+     */
     @Autowired private LPVSQueueService queueService;
 
+    /**
+     * LPVSQueueRepository for accessing and managing LPVSQueue entities.
+     */
     @Autowired private LPVSQueueRepository queueRepository;
 
+    /**
+     * LPVSGitHubService for handling GitHub-related actions.
+     */
     private LPVSGitHubService gitHubService;
 
+    /**
+     * LPVSExitHandler for handling application exit scenarios.
+     */
     private LPVSExitHandler exitHandler;
 
     private static final String SIGNATURE = "X-Hub-Signature-256";
@@ -72,6 +89,16 @@ public class GitHubWebhooksController {
     private static final String ERROR = "Error";
     private static final String ALGORITHM = "HmacSHA256";
 
+    /**
+     * Constructor for GitHubWebhooksController.
+     * Initializes LPVSQueueService, LPVSGitHubService, LPVSQueueRepository, GitHub secret, and LPVSExitHandler.
+     *
+     * @param queueService      LPVSQueueService for handling user-related business logic.
+     * @param gitHubService     LPVSGitHubService for handling GitHub-related actions.
+     * @param queueRepository   LPVSQueueRepository for accessing and managing LPVSQueue entities.
+     * @param GITHUB_SECRET     The GitHub secret used for validating webhook payloads.
+     * @param exitHandler       LPVSExitHandler for handling application exit scenarios.
+     */
     public GitHubWebhooksController(
             LPVSQueueService queueService,
             LPVSGitHubService gitHubService,
@@ -86,7 +113,7 @@ public class GitHubWebhooksController {
     }
 
     /**
-     * Handles the GitHub webhook events and processes the payload.
+     * Endpoint for handling GitHub webhook events and processing the payload.
      *
      * @param signature The signature of the webhook event.
      * @param payload   The payload of the webhook event.

--- a/src/main/java/com/lpvs/controller/LPVSWebController.java
+++ b/src/main/java/com/lpvs/controller/LPVSWebController.java
@@ -39,17 +39,55 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Controller class for handling web-related requests in LPVS.
+ * This class manages user information, login details, history, results, and dashboard pages.
+ */
 @Controller
 @Slf4j
 public class LPVSWebController implements ErrorController {
+
+    /**
+     * Repository for LPVS members.
+     */
     private LPVSMemberRepository memberRepository;
+
+    /**
+     * Repository for detected licenses.
+     */
     private LPVSDetectedLicenseRepository detectedLicenseRepository;
+
+    /**
+     * Repository for LPVS pull requests.
+     */
     private LPVSPullRequestRepository lpvsPullRequestRepository;
+
+    /**
+     * Repository for LPVS licenses.
+     */
     private LPVSLicenseRepository licenseRepository;
+
+    /**
+     * Service for checking user logins.
+     */
     private LPVSLoginCheckService lpvsLoginCheckService;
 
+    /**
+     * Service for generating LPVS statistics.
+     */
     private LPVSStatisticsService lpvsStatisticsService;
 
+    /**
+     * Constructor for LPVSWebController.
+     * Initializes repositories and services required for web-related functionality.
+     *
+     * @param memberRepository           Repository for LPVS members.
+     * @param detectedLicenseRepository  Repository for detected licenses.
+     * @param lpvsPullRequestRepository  Repository for LPVS pull requests.
+     * @param licenseRepository           Repository for LPVS licenses.
+     * @param lpvsLoginCheckService       Service for checking user logins.
+     * @param lpvsStatisticsService       Service for generating LPVS statistics.
+     */
     public LPVSWebController(
             LPVSMemberRepository memberRepository,
             LPVSDetectedLicenseRepository detectedLicenseRepository,
@@ -65,9 +103,20 @@ public class LPVSWebController implements ErrorController {
         this.lpvsStatisticsService = lpvsStatisticsService;
     }
 
+    /**
+     * Controller class for managing public web API endpoints in LPVS.
+     * This class provides endpoints for retrieving user information, login details, and performing user-related actions.
+     */
     @RequestMapping("/api/v1/web")
     @RestController
-    class PublicInterface {
+    class WebApiEndpoints {
+
+        /**
+         * Retrieves personal information settings for the authenticated user.
+         *
+         * @param authentication The authentication object.
+         * @return LPVSMember object representing personal information settings.
+         */
         @GetMapping("/user/info")
         @ResponseBody
         public LPVSMember personalInfoSettings(Authentication authentication) {
@@ -75,6 +124,12 @@ public class LPVSWebController implements ErrorController {
             return lpvsLoginCheckService.getMemberFromMemberMap(authentication);
         }
 
+        /**
+         * Retrieves login details for the authenticated user.
+         *
+         * @param authentication The authentication object.
+         * @return LPVSLoginMember object representing login details.
+         */
         @GetMapping("/user/login")
         @ResponseBody
         public LPVSLoginMember loginMember(Authentication authentication) {
@@ -90,6 +145,13 @@ public class LPVSWebController implements ErrorController {
             }
         }
 
+        /**
+         * Updates user settings based on the provided map.
+         *
+         * @param map             Map containing user settings.
+         * @param authentication The authentication object.
+         * @return ResponseEntity with LPVSMember representing the updated user.
+         */
         @PostMapping("/user/update")
         public ResponseEntity<LPVSMember> postSettingTest(
                 @RequestBody Map<String, String> map, Authentication authentication) {
@@ -105,6 +167,15 @@ public class LPVSWebController implements ErrorController {
             return ResponseEntity.ok().body(findMember);
         }
 
+        /**
+         * Retrieves the history page entity based on the specified type and name.
+         *
+         * @param type           The type of history (e.g., user, organization).
+         * @param name           The name of the user or organization.
+         * @param pageable       The pageable object for pagination.
+         * @param authentication The authentication object.
+         * @return HistoryEntity containing a list of LPVSHistory items and total count.
+         */
         @ResponseBody
         @GetMapping("/history/{type}/{name}")
         public HistoryEntity newHistoryPageByUser(
@@ -148,6 +219,14 @@ public class LPVSWebController implements ErrorController {
             return historyEntity;
         }
 
+        /**
+         * Retrieves the LPVSResult for a specific pull request ID.
+         *
+         * @param prId           The pull request ID.
+         * @param pageable       The pageable object for pagination.
+         * @param authentication The authentication object.
+         * @return LPVSResult containing result details for the specified pull request.
+         */
         @ResponseBody
         @GetMapping("/result/{prId}")
         public LPVSResult resultPage(
@@ -230,6 +309,14 @@ public class LPVSWebController implements ErrorController {
             return lpvsResult;
         }
 
+        /**
+         * Retrieves the Dashboard entity based on the specified type and name.
+         *
+         * @param type           The type of the dashboard (e.g., user, organization).
+         * @param name           The name of the user or organization.
+         * @param authentication The authentication object.
+         * @return Dashboard entity containing statistics and insights.
+         */
         @ResponseBody
         @GetMapping("dashboard/{type}/{name}")
         public Dashboard dashboardPage(
@@ -244,6 +331,11 @@ public class LPVSWebController implements ErrorController {
         }
     }
 
+    /**
+     * Redirects to the default error page.
+     *
+     * @return String representing the path to the error page.
+     */
     @GetMapping("/error")
     public String redirect() {
         return "index.html";

--- a/src/main/java/com/lpvs/controller/package-info.java
+++ b/src/main/java/com/lpvs/controller/package-info.java
@@ -1,13 +1,20 @@
 /**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+/**
  * This package contains the controller classes for handling various aspects of the License Pre-Validation Service (LPVS).
  * Controllers in this package manage interactions related to GitHub webhooks, user interfaces, and API endpoints.
- *
+ * <p>
  * - {@link com.lpvs.controller.GitHubWebhooksController}: Manages GitHub webhook events, processes payloads, and interacts
  *   with LPVS services for queue handling and GitHub operations.
- *
+ * </p><p>
  * - {@link com.lpvs.controller.LPVSWebController}: Controls the web interface and API endpoints for LPVS, including user
  *   information, login status, user settings, history, results, and dashboard-related functionalities.
- *
+ * </p>
  * These controllers play a crucial role in integrating LPVS functionalities into different parts of the application,
  * such as handling external events, providing user interfaces, and exposing APIs for external integrations.
  */

--- a/src/main/java/com/lpvs/controller/package-info.java
+++ b/src/main/java/com/lpvs/controller/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * This package contains the controller classes for handling various aspects of the License Pre-Validation Service (LPVS).
+ * Controllers in this package manage interactions related to GitHub webhooks, user interfaces, and API endpoints.
+ *
+ * - {@link com.lpvs.controller.GitHubWebhooksController}: Manages GitHub webhook events, processes payloads, and interacts
+ *   with LPVS services for queue handling and GitHub operations.
+ *
+ * - {@link com.lpvs.controller.LPVSWebController}: Controls the web interface and API endpoints for LPVS, including user
+ *   information, login status, user settings, history, results, and dashboard-related functionalities.
+ *
+ * These controllers play a crucial role in integrating LPVS functionalities into different parts of the application,
+ * such as handling external events, providing user interfaces, and exposing APIs for external integrations.
+ */
+package com.lpvs.controller;

--- a/src/main/java/com/lpvs/package-info.java
+++ b/src/main/java/com/lpvs/package-info.java
@@ -1,4 +1,11 @@
 /**
+ * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * Use of this source code is governed by a MIT license that can be
+ * found in the LICENSE file.
+ */
+
+/**
  * Provides the main classes and components for the License Pre-Validation Service (LPVS) application.
  * LPVS is an open-source tool designed to mitigate license-related risks in open-source projects.
  * It analyzes the project, identifies components and licenses, and generates potential issue cases.

--- a/src/main/java/com/lpvs/package-info.java
+++ b/src/main/java/com/lpvs/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Provides the main classes and components for the License Pre-Validation Service (LPVS) application.
+ * LPVS is an open-source tool designed to mitigate license-related risks in open-source projects.
+ * It analyzes the project, identifies components and licenses, and generates potential issue cases.
+ * The {@link com.lpvs.LicensePreValidationSystem} class is the main entry point for LPVS.
+ *
+ * <p>
+ * The LPVS project aims to assist developers in ensuring license compliance for their open-source code.
+ * It integrates with the SCANOSS license scanner, GitHub review system, and offers features for
+ * comprehensive issue descriptions, continuous monitoring, and risk mitigation.
+ * </p>
+ */
+package com.lpvs;

--- a/src/test/java/com/lpvs/controller/GitHubWebhooksControllerTest.java
+++ b/src/test/java/com/lpvs/controller/GitHubWebhooksControllerTest.java
@@ -148,7 +148,7 @@ public class GitHubWebhooksControllerTest {
                         + "}"
                         + "}";
         try {
-            gitHubWebhooksController.setProps();
+            gitHubWebhooksController.initializeGitHubSecret();
             boolean secret = gitHubWebhooksController.wrongSecret(signature, json_to_test);
             assertEquals(secret, false);
             secret = gitHubWebhooksController.wrongSecret(signature + " ", json_to_test);

--- a/src/test/java/com/lpvs/controller/LPVSWebControllerTest.java
+++ b/src/test/java/com/lpvs/controller/LPVSWebControllerTest.java
@@ -66,7 +66,7 @@ public class LPVSWebControllerTest {
         when(loginCheckService.getMemberFromMemberMap(authentication)).thenReturn(member);
 
         LPVSMember result =
-                webController.new PublicInterface().personalInfoSettings(authentication);
+                webController.new WebApiEndpoints().personalInfoSettings(authentication);
 
         assertNotNull(result);
         assertEquals(1L, result.getId());
@@ -86,7 +86,7 @@ public class LPVSWebControllerTest {
         when(loginCheckService.getOauthLoginMemberMap(authentication))
                 .thenReturn(oauthLoginMemberMap);
         when(loginCheckService.getMemberFromMemberMap(authentication)).thenReturn(member);
-        LPVSLoginMember result = webController.new PublicInterface().loginMember(authentication);
+        LPVSLoginMember result = webController.new WebApiEndpoints().loginMember(authentication);
         assertNotNull(result);
         assertNotNull(result.getMember());
         assertEquals(1L, result.getMember().getId());
@@ -100,7 +100,7 @@ public class LPVSWebControllerTest {
     public void testLoginMemberNotLoggedIn() {
         Authentication authentication = mock(Authentication.class);
         when(loginCheckService.getOauthLoginMemberMap(authentication)).thenReturn(null);
-        LPVSLoginMember result = webController.new PublicInterface().loginMember(authentication);
+        LPVSLoginMember result = webController.new WebApiEndpoints().loginMember(authentication);
         assertNotNull(result);
         assertNull(result.getMember());
     }
@@ -117,7 +117,7 @@ public class LPVSWebControllerTest {
         when(loginCheckService.getMemberFromMemberMap(authentication)).thenReturn(member);
         when(memberRepository.saveAndFlush(member)).thenReturn(member);
         ResponseEntity<LPVSMember> responseEntity =
-                webController.new PublicInterface().postSettingTest(map, authentication);
+                webController.new WebApiEndpoints().postSettingTest(map, authentication);
         assertNotNull(responseEntity);
         assertEquals(responseEntity.getBody(), member);
         assertEquals("UpdatedUser", member.getNickname());
@@ -138,7 +138,7 @@ public class LPVSWebControllerTest {
                 .thenThrow(new DataIntegrityViolationException("DuplicatedKeyException"));
         assertThrows(
                 IllegalArgumentException.class,
-                () -> webController.new PublicInterface().postSettingTest(map, authentication));
+                () -> webController.new WebApiEndpoints().postSettingTest(map, authentication));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class LPVSWebControllerTest {
         when(detectedLicenseRepository.existsIssue(pullRequest)).thenReturn(false);
 
         HistoryEntity result =
-                webController.new PublicInterface()
+                webController.new WebApiEndpoints()
                         .newHistoryPageByUser(type, name, pageable, authentication);
 
         assertNotNull(result);
@@ -232,7 +232,7 @@ public class LPVSWebControllerTest {
                 .thenReturn(1L);
 
         LPVSResult result =
-                webController.new PublicInterface().resultPage(prId, pageable, authentication);
+                webController.new WebApiEndpoints().resultPage(prId, pageable, authentication);
 
         assertNotNull(result);
         assertNotNull(result.getLpvsResultInfo());
@@ -253,7 +253,7 @@ public class LPVSWebControllerTest {
         when(statisticsService.getDashboardEntity(type, name, authentication))
                 .thenReturn(mockDashboard);
         Dashboard dashboard =
-                webController.new PublicInterface().dashboardPage(type, name, authentication);
+                webController.new WebApiEndpoints().dashboardPage(type, name, authentication);
         assertNotNull(dashboard);
     }
 


### PR DESCRIPTION
# Description

Here I want to enable Javadoc generation and publication on Github pages.
In this PR I covered `com.lpvs` and `com.lpvs.controller` packages by comments. 
Other packages will be covered by Javadoc comments step-by-step in other PRs.
Also, I've created the task #307 with the request to update comments.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactoring
- [X] Documentation update
- [X] This change requires a documentation update
- [X] CI system update
- [ ] Test Coverage update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
