### PR TITLE
fix: Fix Github action step to generate Javadoc

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,23 +16,24 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2
         with:
-          distribution: 'adopt'
           java-version: '11'
+          distribution: 'temurin'
+          cache: maven
 
       - name: Build and generate Javadoc
         run: mvn clean package javadoc:javadoc
 
       - name: Check if gh-pages branch exists
-        run: git show-ref --verify --quiet refs/heads/gh-pages
+        id: check-gh-pages
+        run: git show-ref --verify --quiet refs/heads/gh-pages || echo "Branch does not exist"
 
       - name: Create gh-pages branch if it doesn't exist
+        if: steps.check-gh-pages.outputs.exit-code
         run: |
-          if [ $? -ne 0 ]; then
-            git checkout --orphan gh-pages
-            git rm -rf .
-            git commit --allow-empty -m "Initial commit for gh-pages branch"
-            git push origin gh-pages
-          fi
+          git checkout --orphan gh-pages
+          git rm -rf .
+          git commit --allow-empty -m "Initial commit for gh-pages branch"
+          git push origin gh-pages
 
       - name: Copy Javadoc to gh-pages branch
         run: |


### PR DESCRIPTION
# Description

This PR includes the fix for Javadoc generation github action step.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [X] CI system update
- [ ] Test Coverage update

