### PR TITLE
test: added tests for getRepositoryOrganization and getRepositoryName…

### DIFF
--- a/src/main/java/com/lpvs/util/LPVSWebhookUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSWebhookUtil.java
@@ -115,12 +115,12 @@ public class LPVSWebhookUtil {
     public static String getRepositoryOrganization(LPVSQueue webhookConfig) {
         if (null == webhookConfig) {
             log.error("Webhook Config is absent");
-            return "Webhook is absent";
+            throw new IllegalArgumentException("Webhook is absent");
         }
 
         if (null == webhookConfig.getRepositoryUrl()) {
             log.error("No repository URL info in webhook config");
-            return "No repository URL info in webhook config";
+            throw new IllegalArgumentException("No repository URL info in webhook config");
         }
 
         List<String> url = Arrays.asList(webhookConfig.getRepositoryUrl().split("/"));
@@ -136,12 +136,12 @@ public class LPVSWebhookUtil {
     public static String getRepositoryName(LPVSQueue webhookConfig) {
         if (null == webhookConfig) {
             log.error("Webhook Config is absent");
-            return "Webhook is absent";
+            throw new IllegalArgumentException("Webhook is absent");
         }
 
         if (null == webhookConfig.getRepositoryUrl()) {
             log.error("No repository URL info in webhook config");
-            return "No repository URL info in webhook config";
+            throw new IllegalArgumentException("No repository URL info in webhook config");
         }
 
         List<String> url = Arrays.asList(webhookConfig.getRepositoryUrl().split("/"));
@@ -167,17 +167,17 @@ public class LPVSWebhookUtil {
     public static String getPullRequestId(LPVSQueue webhookConfig) {
         if (null == webhookConfig) {
             log.error("Webhook Config is absent");
-            return "Webhook is absent";
+            throw new IllegalArgumentException("Webhook is absent");
         }
 
         if (null == webhookConfig.getRepositoryUrl()) {
             log.error("No repository URL info in webhook config");
-            return "No repository URL info in webhook config";
+            throw new IllegalArgumentException("No repository URL info in webhook config");
         }
 
         if (null == webhookConfig.getPullRequestUrl()) {
             log.error("Pull Request URL is absent in webhook config");
-            return "Pull Request URL is absent in webhook config";
+            throw new IllegalArgumentException("Pull Request URL is absent in webhook config");
         }
 
         List<String> url = Arrays.asList(webhookConfig.getPullRequestUrl().split("/"));

--- a/src/test/java/com/lpvs/util/LPVSWebhookUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSWebhookUtilTest.java
@@ -178,6 +178,72 @@ public class LPVSWebhookUtilTest {
     }
 
     @Nested
+    public class TestGetRepositoryOrganization {
+
+        @Mock private LPVSQueue mockWebhookConfig;
+
+        @Test
+        public void testGetRepositoryOrganizationWithValidConfig() {
+            mockWebhookConfig = new LPVSQueue();
+            mockWebhookConfig.setRepositoryUrl("https://github.com/repo/org");
+            String result = LPVSWebhookUtil.getRepositoryOrganization(mockWebhookConfig);
+            assertEquals("repo", result);
+        }
+
+        @Test
+        public void testGetRepositoryOrganizationWithNullConfig() {
+            mockWebhookConfig = null;
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                LPVSWebhookUtil.getRepositoryOrganization(mockWebhookConfig);
+            });
+            assertEquals("Webhook is absent", exception.getMessage());
+        }
+
+        @Test
+        public void testGetRepositoryOrganizationWithNullRepositoryUrl() {
+            mockWebhookConfig = new LPVSQueue();
+            mockWebhookConfig.setRepositoryUrl(null);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                LPVSWebhookUtil.getRepositoryOrganization(mockWebhookConfig);
+            });
+            assertEquals("No repository URL info in webhook config", exception.getMessage());
+        }
+    }
+
+    @Nested
+    public class TestGetRepositoryName {
+
+        @Mock private LPVSQueue mockWebhookConfig;
+
+        @Test
+        public void testGetRepositoryNameWithValidConfig() {
+            mockWebhookConfig = new LPVSQueue();
+            mockWebhookConfig.setRepositoryUrl("https://github.com/repo/org");
+            String result = LPVSWebhookUtil.getRepositoryName(mockWebhookConfig);
+            assertEquals("org", result);
+        }
+
+        @Test
+        public void testGetRepositoryNameWithNullConfig() {
+            mockWebhookConfig = null;
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                LPVSWebhookUtil.getRepositoryName(mockWebhookConfig);
+            });
+            assertEquals("Webhook is absent", exception.getMessage());
+        }
+
+        @Test
+        public void testGetRepositoryNameWithNullRepositoryUrl() {
+            mockWebhookConfig = new LPVSQueue();
+            mockWebhookConfig.setRepositoryUrl(null);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+                LPVSWebhookUtil.getRepositoryName(mockWebhookConfig);
+            });
+            assertEquals("No repository URL info in webhook config", exception.getMessage());
+        }
+    }
+
+    @Nested
     public class TestGetPullRequestId {
 
         @Mock private LPVSQueue mockWebhookConfig;
@@ -194,16 +260,16 @@ public class LPVSWebhookUtilTest {
         @Test
         public void testGetPullRequestIdWithNullConfig() {
             mockWebhookConfig = null;
-            String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
-            assertEquals("Webhook is absent", result);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->{LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);});
+            assertEquals("Webhook is absent", exception.getMessage());
         }
 
         @Test
         public void testGetPullRequestIdWithNullRepositoryUrl() {
             mockWebhookConfig = new LPVSQueue();
             mockWebhookConfig.setRepositoryUrl(null);
-            String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
-            assertEquals("No repository URL info in webhook config", result);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->{LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);});
+            assertEquals("No repository URL info in webhook config", exception.getMessage());
         }
 
         @Test
@@ -211,8 +277,8 @@ public class LPVSWebhookUtilTest {
             mockWebhookConfig = new LPVSQueue();
             mockWebhookConfig.setRepositoryUrl("https://github.com/repo");
             mockWebhookConfig.setPullRequestUrl(null);
-            String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
-            assertEquals("Pull Request URL is absent in webhook config", result);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->{LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);});
+            assertEquals("Pull Request URL is absent in webhook config", exception.getMessage());
         }
     }
 


### PR DESCRIPTION
…, changed tests for getPullRequestId, fix: changed WebhookUtil methods to return exceptions and not strings #301

# Pull Request

## Description

When an error occurs in some functions in LPVSWebhookUnit , an illegalArgumentException is now thrown instead of a string being returned. Unit tests for these functions also created/modified.

Fixes # (issue)
I resolved issue #301  

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [x] Documentation update
- [x] This change requires a documentation update
- [x] CI system update
- [ ] Test Coverage update

## Testing

I basically added tests so i don't think i can write something in this section.

**Test Configuration**:
* Java: v11
* LPVS Release: v1.2.0

# Checklist:

- [✓ ] My code follows the style guidelines of this project
- [ ] My code meets the required code coverage for lines (90% and above)
- [ ] My code meets the required code coverage for branches (80% and above)
- [ ✓] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✓ ] My changes generate no new warnings
- [✓ ] I have added tests that prove my fix is effective or that my feature works
- [✓ ] New and existing unit tests pass locally with my changes
