### PR TITLE
fix: Apply security install of python package into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install SCANOSS
-RUN pip3 install scanoss
+RUN pip3 install scanoss --require-hashes
 
 # Allow to listen port 7896
 EXPOSE 7896


### PR DESCRIPTION
# Pull Request

## Description

pip does not perform checks to protect against remote tampering. If add `--require-hashes` option, we can check the hash of the package being installed.

Fixes #321 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI system update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] My code meets the required code coverage for lines (90% and above)
- [ ] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
