### PR TITLE
fix: Add `throw Exception` in case of error in `LPVSWebhookUtil` class

### DIFF
--- a/src/main/java/com/lpvs/service/LPVSGitHubService.java
+++ b/src/main/java/com/lpvs/service/LPVSGitHubService.java
@@ -117,8 +117,8 @@ public class LPVSGitHubService {
             }
             log.debug("Saving files...");
             return LPVSFileUtil.saveGithubDiffs(pullRequest.listFiles(), webhookConfig);
-        } catch (IOException e) {
-            log.error("Can't authorize getPullRequestFiles() " + e);
+        } catch (IOException | IllegalArgumentException e) {
+            log.error("Can't authorize getPullRequestFiles(): " + e.getMessage());
         }
         return null;
     }
@@ -176,8 +176,8 @@ public class LPVSGitHubService {
                     null,
                     "Scanning opensource licenses",
                     "[License Pre-Validation Service]");
-        } catch (IOException e) {
-            log.error("Can't authorize setPendingCheck()" + e);
+        } catch (IOException | IllegalArgumentException e) {
+            log.error("Can't authorize setPendingCheck(): " + e.getMessage());
         }
     }
 
@@ -200,8 +200,8 @@ public class LPVSGitHubService {
                     null,
                     "Scanning process failed",
                     "[License Pre-Validation Service]");
-        } catch (IOException e) {
-            log.error("Can't authorize setErrorCheck() " + e);
+        } catch (IOException | IllegalArgumentException e) {
+            log.error("Can't authorize setErrorCheck(): " + e.getMessage());
         }
     }
 
@@ -366,10 +366,10 @@ public class LPVSGitHubService {
                         "No license issue detected",
                         "[License Pre-Validation Service]");
             }
-        } catch (IOException | NullPointerException e) {
+        } catch (IOException | NullPointerException | IllegalArgumentException e) {
             lpvsPullRequest.setStatus(LPVSPullRequestStatus.INTERNAL_ERROR.toString());
             pullRequestRepository.saveAndFlush(lpvsPullRequest);
-            log.error("Can't authorize commentResults() " + e);
+            log.error("Can't authorize commentResults(): " + e.getMessage());
             try {
                 GHRepository repository =
                         gitHub.getRepository(
@@ -408,8 +408,8 @@ public class LPVSGitHubService {
             } else {
                 return license.getKey();
             }
-        } catch (IOException e) {
-            log.error("Can't authorize getRepositoryLicense() " + e);
+        } catch (IOException | IllegalArgumentException e) {
+            log.error("Can't authorize getRepositoryLicense(): " + e.getMessage());
         }
         return "Proprietary";
     }

--- a/src/main/java/com/lpvs/service/LPVSQueueService.java
+++ b/src/main/java/com/lpvs/service/LPVSQueueService.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -208,10 +207,9 @@ public class LPVSQueueService {
      * Asynchronously processes the LPVSQueue element, handling GitHub webhook events.
      *
      * @param webhookConfig The LPVSQueue element to be processed.
-     * @throws IOException If an I/O error occurs.
      */
     @Async("threadPoolTaskExecutor")
-    public void processWebHook(LPVSQueue webhookConfig) throws IOException {
+    public void processWebHook(LPVSQueue webhookConfig) {
         LPVSPullRequest pullRequest = new LPVSPullRequest();
         try {
             log.info("GitHub Webhook processing...");

--- a/src/main/java/com/lpvs/service/scanner/scanoss/LPVSScanossDetectService.java
+++ b/src/main/java/com/lpvs/service/scanner/scanoss/LPVSScanossDetectService.java
@@ -274,7 +274,7 @@ public class LPVSScanossDetectService {
 
             // close reader
             reader.close();
-        } catch (IOException ex) {
+        } catch (IOException | IllegalArgumentException ex) {
             log.error(ex.toString());
         }
         return detectedFiles;

--- a/src/main/java/com/lpvs/util/LPVSWebhookUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSWebhookUtil.java
@@ -111,16 +111,17 @@ public class LPVSWebhookUtil {
      *
      * @param webhookConfig LPVSQueue object containing repository information.
      * @return The organization name.
+     * @throws IllegalArgumentException If the provided LPVSQueue object is null or if the repository URL is absent.
      */
     public static String getRepositoryOrganization(LPVSQueue webhookConfig) {
         if (null == webhookConfig) {
             log.error("Webhook Config is absent");
-            return "Webhook is absent";
+            throw new IllegalArgumentException("Webhook is absent");
         }
 
         if (null == webhookConfig.getRepositoryUrl()) {
             log.error("No repository URL info in webhook config");
-            return "No repository URL info in webhook config";
+            throw new IllegalArgumentException("No repository URL info in webhook config");
         }
 
         List<String> url = Arrays.asList(webhookConfig.getRepositoryUrl().split("/"));
@@ -132,16 +133,17 @@ public class LPVSWebhookUtil {
      *
      * @param webhookConfig LPVSQueue object containing repository information.
      * @return The repository name.
+     * @throws IllegalArgumentException If the provided LPVSQueue object is null or if the repository URL is absent.
      */
     public static String getRepositoryName(LPVSQueue webhookConfig) {
         if (null == webhookConfig) {
             log.error("Webhook Config is absent");
-            return "Webhook is absent";
+            throw new IllegalArgumentException("Webhook is absent");
         }
 
         if (null == webhookConfig.getRepositoryUrl()) {
             log.error("No repository URL info in webhook config");
-            return "No repository URL info in webhook config";
+            throw new IllegalArgumentException("No repository URL info in webhook config");
         }
 
         List<String> url = Arrays.asList(webhookConfig.getRepositoryUrl().split("/"));
@@ -153,8 +155,13 @@ public class LPVSWebhookUtil {
      *
      * @param webhookConfig LPVSQueue object containing repository information.
      * @return The repository URL.
+     * @throws IllegalArgumentException If the provided LPVSQueue object is null.
      */
     public static String getRepositoryUrl(LPVSQueue webhookConfig) {
+        if (null == webhookConfig) {
+            log.error("Webhook Config is absent");
+            throw new IllegalArgumentException("Webhook is absent");
+        }
         return webhookConfig.getRepositoryUrl();
     }
 
@@ -163,21 +170,22 @@ public class LPVSWebhookUtil {
      *
      * @param webhookConfig LPVSQueue object containing pull request information.
      * @return The pull request ID.
+     * @throws IllegalArgumentException If the provided LPVSQueue object is null or if the pull request URL is absent.
      */
     public static String getPullRequestId(LPVSQueue webhookConfig) {
         if (null == webhookConfig) {
             log.error("Webhook Config is absent");
-            return "Webhook is absent";
+            throw new IllegalArgumentException("Webhook is absent");
         }
 
         if (null == webhookConfig.getRepositoryUrl()) {
             log.error("No repository URL info in webhook config");
-            return "No repository URL info in webhook config";
+            throw new IllegalArgumentException("No repository URL info in webhook config");
         }
 
         if (null == webhookConfig.getPullRequestUrl()) {
             log.error("Pull Request URL is absent in webhook config");
-            return "Pull Request URL is absent in webhook config";
+            throw new IllegalArgumentException("Pull Request URL is absent in webhook config");
         }
 
         List<String> url = Arrays.asList(webhookConfig.getPullRequestUrl().split("/"));

--- a/src/test/java/com/lpvs/service/LPVSDetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSDetectServiceTest.java
@@ -109,6 +109,7 @@ public class LPVSDetectServiceTest {
 
             webhookConfig = new LPVSQueue();
             webhookConfig.setId(1L);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             lpvs_file_1 =
                     new LPVSFile(
@@ -398,6 +399,12 @@ public class LPVSDetectServiceTest {
         public void testGetPathByPullRequest() {
 
             LPVSQueue mockWebhookConfig = mock(LPVSQueue.class);
+
+            when(mockWebhookConfig.getRepositoryUrl())
+                    .thenReturn("https://github.com/Samsung/LPVS");
+
+            when(mockWebhookConfig.getPullRequestUrl())
+                    .thenReturn("https://github.com/Samsung/LPVS/pull/1");
 
             String result = LPVSDetectService.getPathByPullRequest(mockWebhookConfig);
 

--- a/src/test/java/com/lpvs/service/LPVSGitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSGitHubServiceTest.java
@@ -189,6 +189,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig.setPullRequestAPIUrl(url_pr_2);
             webhookConfig.setHeadCommitSHA(commit_sha);
             webhookConfig.setPullRequestUrl(url_pr_2);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -606,6 +607,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig.setAction(LPVSPullRequestAction.OPEN);
             webhookConfig.setPullRequestAPIUrl(url_pr_3);
             webhookConfig.setPullRequestUrl(url_pr_3);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -714,6 +716,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig.setAction(LPVSPullRequestAction.OPEN);
             webhookConfig.setPullRequestAPIUrl(url_pr_3);
             webhookConfig.setPullRequestUrl(url_pr_3);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -824,6 +827,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig.setAction(LPVSPullRequestAction.OPEN);
             webhookConfig.setPullRequestAPIUrl(url_pr_3);
             webhookConfig.setPullRequestUrl(url_pr_3);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -921,6 +925,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig.setAction(LPVSPullRequestAction.OPEN);
             webhookConfig.setPullRequestAPIUrl(url_pr_3);
             webhookConfig.setPullRequestUrl(url_pr_3);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -1174,6 +1179,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig = new LPVSQueue();
             webhookConfig.setHeadCommitSHA(head_commit_sha);
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -1281,6 +1287,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig = new LPVSQueue();
             webhookConfig.setHeadCommitSHA(head_commit_sha);
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -1496,6 +1503,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig = new LPVSQueue();
             webhookConfig.setHeadCommitSHA(head_commit_sha);
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -1603,6 +1611,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig = new LPVSQueue();
             webhookConfig.setHeadCommitSHA(head_commit_sha);
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -1829,6 +1838,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestAPIUrl(url_pr_3);
             webhookConfig.setPullRequestUrl(url_pr_3);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -2004,6 +2014,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig.setPullRequestAPIUrl(url_pr_2);
             webhookConfig.setHeadCommitSHA(commit_sha);
             webhookConfig.setPullRequestUrl(url_pr_2);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -3596,6 +3607,7 @@ public class LPVSGitHubServiceTest {
         void setUp() {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -3690,6 +3702,7 @@ public class LPVSGitHubServiceTest {
         void setUp() {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
             try {
                 when(mocked_instance_gh.getRepository(
                                 LPVSWebhookUtil.getRepositoryOrganization(webhookConfig)
@@ -3782,6 +3795,7 @@ public class LPVSGitHubServiceTest {
         void setUp() {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -3882,6 +3896,7 @@ public class LPVSGitHubServiceTest {
         void setUp() {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
 
             try {
                 when(mocked_instance_gh.getRepository(
@@ -3978,6 +3993,7 @@ public class LPVSGitHubServiceTest {
         void setUp() {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
         }
 
         @Test
@@ -4027,6 +4043,7 @@ public class LPVSGitHubServiceTest {
         void setUp() {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr_1);
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
         }
 
         @Test
@@ -4185,6 +4202,7 @@ public class LPVSGitHubServiceTest {
             webhookConfig = new LPVSQueue();
             webhookConfig.setPullRequestUrl(url_pr_1);
             webhookConfig.setPullRequestAPIUrl("http://url.com");
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
             lpvsPullRequest = new LPVSPullRequest();
         }
 

--- a/src/test/java/com/lpvs/service/LPVSQueueServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSQueueServiceTest.java
@@ -849,6 +849,7 @@ public class LPVSQueueServiceTest {
             webhookConfig.setAttempts(100);
             webhookConfig.setDate(new Date());
             webhookConfig.setUserId("id");
+            webhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
             when(mocked_queueRepository.getQueueList()).thenReturn(List.of(webhookConfig));
             when(mocked_lpvsPullRequestRepository.saveAndFlush(Mockito.any(LPVSPullRequest.class)))
                     .thenAnswer(i -> i.getArguments()[0]);

--- a/src/test/java/com/lpvs/service/scanner/scanoss/LPVSScanossDetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/scanner/scanoss/LPVSScanossDetectServiceTest.java
@@ -9,7 +9,6 @@ package com.lpvs.service.scanner.scanoss;
 import com.lpvs.entity.LPVSLicense;
 import com.lpvs.entity.LPVSQueue;
 import com.lpvs.repository.LPVSLicenseRepository;
-import com.lpvs.service.LPVSGitHubService;
 import com.lpvs.service.LPVSLicenseService;
 import com.lpvs.util.LPVSWebhookUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -38,8 +37,6 @@ public class LPVSScanossDetectServiceTest {
     @Mock private LPVSQueue lpvsQueue;
 
     @Mock private LPVSLicenseService licenseService;
-
-    @Mock private LPVSGitHubService gitHubService;
 
     @Mock private LPVSLicenseRepository lpvsLicenseRepository;
 
@@ -88,8 +85,9 @@ public class LPVSScanossDetectServiceTest {
         LPVSScanossDetectService scanossDetectService =
                 new LPVSScanossDetectService(false, licenseService, lpvsLicenseRepository);
         String licenseConflictsSource = "scanner";
-        Mockito.when(LPVSWebhookUtil.getRepositoryName(lpvsQueue)).thenReturn("C");
         Mockito.when(lpvsQueue.getHeadCommitSHA()).thenReturn("A_B");
+        Mockito.when(lpvsQueue.getRepositoryUrl()).thenReturn("https://github.com/Samsung/LPVS");
+        Mockito.when(LPVSWebhookUtil.getRepositoryName(lpvsQueue)).thenReturn("C");
         Mockito.when(lpvsLicenseRepository.save(Mockito.any(LPVSLicense.class)))
                 .thenAnswer(i -> i.getArguments()[0]);
         ReflectionTestUtils.setField(
@@ -106,8 +104,10 @@ public class LPVSScanossDetectServiceTest {
                 new LPVSScanossDetectService(false, licenseService, lpvsLicenseRepository);
         String licenseConflictsSource = "scanner";
         LPVSQueue webhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(LPVSWebhookUtil.getRepositoryName(webhookConfig)).thenReturn("C");
         Mockito.when(webhookConfig.getHeadCommitSHA()).thenReturn("A_B");
+        Mockito.when(webhookConfig.getRepositoryUrl())
+                .thenReturn("https://github.com/Samsung/LPVS");
+        Mockito.when(LPVSWebhookUtil.getRepositoryName(webhookConfig)).thenReturn("C");
         Mockito.when(lpvsLicenseRepository.save(Mockito.any(LPVSLicense.class)))
                 .thenAnswer(i -> i.getArguments()[0]);
         ReflectionTestUtils.setField(
@@ -125,8 +125,10 @@ public class LPVSScanossDetectServiceTest {
                 new LPVSScanossDetectService(false, licenseService, lpvsLicenseRepository);
         String licenseConflictsSource = "scanner";
         LPVSQueue webhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(LPVSWebhookUtil.getRepositoryName(webhookConfig)).thenReturn("A");
         Mockito.when(webhookConfig.getHeadCommitSHA()).thenReturn(null);
+        Mockito.when(webhookConfig.getRepositoryUrl())
+                .thenReturn("https://github.com/Samsung/LPVS");
+        Mockito.when(LPVSWebhookUtil.getRepositoryName(webhookConfig)).thenReturn("A");
         Mockito.when(webhookConfig.getPullRequestUrl()).thenReturn("A/B");
         ReflectionTestUtils.setField(
                 licenseService, "licenseConflictsSource", licenseConflictsSource);
@@ -137,9 +139,11 @@ public class LPVSScanossDetectServiceTest {
     public void testWithNullHeadCommitSHADB() {
         String licenseConflictsSource = "db";
         LPVSQueue webhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(LPVSWebhookUtil.getRepositoryName(webhookConfig)).thenReturn("A");
         Mockito.when(webhookConfig.getHeadCommitSHA()).thenReturn(null);
+        Mockito.when(webhookConfig.getRepositoryUrl())
+                .thenReturn("https://github.com/Samsung/LPVS");
         Mockito.when(webhookConfig.getPullRequestUrl()).thenReturn("A/B");
+        Mockito.when(LPVSWebhookUtil.getRepositoryName(webhookConfig)).thenReturn("A");
         ReflectionTestUtils.setField(
                 licenseService, "licenseConflictsSource", licenseConflictsSource);
         Assertions.assertNotNull(scanossDetectService.checkLicenses(webhookConfig));
@@ -147,6 +151,9 @@ public class LPVSScanossDetectServiceTest {
 
     @Test
     public void testRunScan_StatusEqualsOne() throws Exception {
+        Mockito.when(lpvsQueue.getRepositoryUrl()).thenReturn("https://github.com/Samsung/LPVS");
+        Mockito.when(lpvsQueue.getPullRequestUrl())
+                .thenReturn("https://github.com/Samsung/LPVS/pull/1");
         Process process = Mockito.mock(Process.class);
         InputStream errorStream =
                 new ByteArrayInputStream(
@@ -178,6 +185,8 @@ public class LPVSScanossDetectServiceTest {
     @Test
     public void testRunScan_StatusEqualsZero() throws Exception {
         Process process = Mockito.mock(Process.class);
+        when(lpvsQueue.getRepositoryUrl()).thenReturn("https://github.com/Samsung/LPVS");
+        when(lpvsQueue.getPullRequestUrl()).thenReturn("https://github.com/Samsung/LPVS/pull/1");
         try (MockedConstruction<ProcessBuilder> mockedPb =
                 Mockito.mockConstruction(
                         ProcessBuilder.class,

--- a/src/test/java/com/lpvs/util/LPVSWebhookUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSWebhookUtilTest.java
@@ -190,30 +190,6 @@ public class LPVSWebhookUtilTest {
             String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
             assertEquals("123", result);
         }
-
-        @Test
-        public void testGetPullRequestIdWithNullConfig() {
-            mockWebhookConfig = null;
-            String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
-            assertEquals("Webhook is absent", result);
-        }
-
-        @Test
-        public void testGetPullRequestIdWithNullRepositoryUrl() {
-            mockWebhookConfig = new LPVSQueue();
-            mockWebhookConfig.setRepositoryUrl(null);
-            String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
-            assertEquals("No repository URL info in webhook config", result);
-        }
-
-        @Test
-        public void testGetPullRequestIdWithNullPullRequestUrl() {
-            mockWebhookConfig = new LPVSQueue();
-            mockWebhookConfig.setRepositoryUrl("https://github.com/repo");
-            mockWebhookConfig.setPullRequestUrl(null);
-            String result = LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
-            assertEquals("Pull Request URL is absent in webhook config", result);
-        }
     }
 
     @Nested
@@ -221,8 +197,72 @@ public class LPVSWebhookUtilTest {
 
         @Test
         public void checkNull() {
-            assertEquals(LPVSWebhookUtil.getRepositoryOrganization(null), "Webhook is absent");
-            assertEquals(LPVSWebhookUtil.getRepositoryName(null), "Webhook is absent");
+            LPVSQueue mockWebhookConfig = new LPVSQueue();
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getRepositoryOrganization(null);
+                            });
+            assertEquals("Webhook is absent", exception.getMessage());
+
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getRepositoryOrganization(mockWebhookConfig);
+                            });
+            assertEquals("No repository URL info in webhook config", exception.getMessage());
+
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getRepositoryName(null);
+                            });
+            assertEquals("Webhook is absent", exception.getMessage());
+
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getRepositoryName(mockWebhookConfig);
+                            });
+            assertEquals("No repository URL info in webhook config", exception.getMessage());
+
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getRepositoryUrl(null);
+                            });
+            assertEquals("Webhook is absent", exception.getMessage());
+
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getPullRequestId(null);
+                            });
+            assertEquals("Webhook is absent", exception.getMessage());
+
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
+                            });
+            assertEquals("No repository URL info in webhook config", exception.getMessage());
+
+            mockWebhookConfig.setRepositoryUrl("https://github.com/Samsung/LPVS");
+            exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> {
+                                LPVSWebhookUtil.getPullRequestId(mockWebhookConfig);
+                            });
+            assertEquals("Pull Request URL is absent in webhook config", exception.getMessage());
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Description

Current pull request provides correct processing of exceptions in  `LPVSWebhookUtil` class. 
Also, it contains corresponding updates in unit tests. 

Fixes #301 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [X] Test Coverage update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My code meets the required code coverage for lines (90% and above)
- [X] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
