### PR TITLE
fix: Change "npm install" to "npm ci" to install fixed version packag…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18@sha256:a6385a6bb2fdcb7c48fc871e35e32af8daaa82c518900be49b76d10c0058
 
 WORKDIR /frontend
 COPY frontend .
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 # Base image for building lpvs lib


### PR DESCRIPTION
…es for docker image

## Description

The `npm ci` command is similar to the `npm install` command, except that it is intended for use in automated deployment environments where you want to make sure you perform a clean install of your dependencies.

Fixes #320 
Closes #320 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI system update

**Test Configuration**:
* Java: v11
* LPVS Release: v1.x.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code meets the required code coverage for lines (90% and above)
- [x] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
