### PR TITLE
ci: fix and update actions/checkout version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up JDK 17
       uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
       with:

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Build docker container
       run: docker image build --no-cache --progress=plain .

--- a/.github/workflows/findbugs.yml
+++ b/.github/workflows/findbugs.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up JDK 17
       uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
       with:

--- a/.github/workflows/java-format-checker.yml
+++ b/.github/workflows/java-format-checker.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: axel-op/googlejavaformat-action@dbff853fb823671ec5781365233bf86543b13215 # v3
         with:
           args: "--aosp --skip-javadoc-formatting --skip-reflowing-long-strings --skip-sorting-imports --replace"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up JDK 17
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
@@ -137,7 +137,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up JDK
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
@@ -171,7 +171,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           java-version: '17'
@@ -195,7 +195,7 @@ jobs:
           egress-policy: audit
 
       - name: Check out the repo
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Log in to the Container registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -37,7 +37,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up JDK 17
       uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
       with:


### PR DESCRIPTION
# Pull Request

## Description

Update version of actions/checkout.
Dependabot getting the next error while trying to update actions/checkout: 
```
Error processing actions/checkout (Dependabot::SharedHelpers::HelperSubprocessFailed)
error: no such commit d0651293c4a5a52e711f25b41b05b2212f385d28
```
These changes fix incorrect commits and update all uses of the _checkout_ action to the latest version - 4.1.1

## Type of change

Please delete options that are not relevant.

- [x] CI system update

## Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code meets the required code coverage for lines (90% and above)
- [x] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
