### PR TITLE
fix: Fix the issue with duplicated records in pull_requests table and runtime error (missing bean)

### DIFF
--- a/src/main/java/com/lpvs/config/SecurityConfig.java
+++ b/src/main/java/com/lpvs/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -138,5 +139,15 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    /**
+     * Defines a simple ClientRegistrationRepository that always returns null for any registration ID.
+     *
+     * @return ClientRegistrationRepository bean.
+     */
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        return registrationId -> null;
     }
 }

--- a/src/main/java/com/lpvs/repository/LPVSPullRequestRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSPullRequestRepository.java
@@ -30,6 +30,40 @@ public interface LPVSPullRequestRepository extends JpaRepository<LPVSPullRequest
     Date getNow();
 
     /**
+     * Retrieves the latest LPVSPullRequest entity based on the provided criteria.
+     *
+     * @param user                The user associated with the pull request. If {@code null}, this parameter is ignored.
+     * @param repositoryName     The name of the repository associated with the pull request. If {@code null}, this parameter is ignored.
+     * @param pullRequestFilesUrl The URL of the pull request files. If {@code null}, this parameter is ignored.
+     * @param pullRequestHead    The head of the pull request. If {@code null}, this parameter is ignored.
+     * @param pullRequestBase    The base of the pull request. If {@code null}, this parameter is ignored.
+     * @param sender              The sender of the pull request. If {@code null}, this parameter is ignored.
+     * @param status              The status of the pull request. If {@code null}, this parameter is ignored.
+     * @return                    The latest LPVSPullRequest entity matching the provided criteria,
+     *                            or {@code null} if no matching entity is found.
+     */
+    @Query(
+            value =
+                    "SELECT * FROM pull_requests pr "
+                            + "WHERE (:user IS NULL OR pr.user = :user) "
+                            + "AND (:repositoryName IS NULL OR pr.repository_name = :repositoryName) "
+                            + "AND (:pullRequestFilesUrl IS NULL OR pr.diff_url = :pullRequestFilesUrl) "
+                            + "AND (:pullRequestHead IS NULL OR pr.pull_request_head = :pullRequestHead) "
+                            + "AND (:pullRequestBase IS NULL OR pr.pull_request_base = :pullRequestBase) "
+                            + "AND (:sender IS NULL OR pr.sender = :sender) "
+                            + "AND (:status IS NULL OR pr.status = :status) "
+                            + "ORDER BY pr.scan_date DESC LIMIT 1",
+            nativeQuery = true)
+    LPVSPullRequest findLatestByPullRequestInfo(
+            @Param("user") String user,
+            @Param("repositoryName") String repositoryName,
+            @Param("pullRequestFilesUrl") String pullRequestFilesUrl,
+            @Param("pullRequestHead") String pullRequestHead,
+            @Param("pullRequestBase") String pullRequestBase,
+            @Param("sender") String sender,
+            @Param("status") String status);
+
+    /**
      * Find all pull requests with the specified base name, paginated.
      *
      * @param name     The name of the pull request base.

--- a/src/main/resources/database_dump.sql
+++ b/src/main/resources/database_dump.sql
@@ -30,9 +30,9 @@ CREATE TABLE IF NOT EXISTS pull_requests (
   url longtext NOT NULL,
   diff_url longtext,
   status varchar(255) DEFAULT NULL,
-  pull_request_head varchar(255) NOT NULL,
-  pull_request_base varchar(255) NOT NULL,
-  sender varchar(255) NOT NULL,
+  pull_request_head varchar(255) DEFAULT NULL,
+  pull_request_base varchar(255) DEFAULT NULL,
+  sender varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
 );
 
@@ -78,6 +78,9 @@ CREATE TABLE IF NOT EXISTS queue (
   pull_request_diff_url longtext,
   status_callback_url longtext,
   commit_sha varchar(255) DEFAULT NULL,
+  pull_request_base varchar(255) DEFAULT NULL,
+  pull_request_head varchar(255) DEFAULT NULL,
+  sender varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
# Pull Request

## Description

I found that in case the scan fails, LPVS saves pull request information into the table `pull_requests` for each failed attempt. 
This is incorrect behavior. Only one record should be saved for every webhook request.
Also fixed runtime issue with missing ClientRegistrationRepository bean.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [X] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update

## Testing

**Test Configuration**:
* Java: v17
* LPVS Release: v1.4.1

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My code meets the required code coverage for lines (90% and above)
- [X] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
