### PR TITLE
refactor: LPVSScanossDetectService refactoring and unit test fix

### DIFF
--- a/src/test/java/com/lpvs/service/scan/scanner/LPVSScanossDetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/scan/scanner/LPVSScanossDetectServiceTest.java
@@ -123,11 +123,20 @@ public class LPVSScanossDetectServiceTest {
         Mockito.when(webhookConfig.getHeadCommitSHA()).thenReturn(null);
         Mockito.when(webhookConfig.getRepositoryUrl())
                 .thenReturn("https://github.com/Samsung/LPVS");
-        Mockito.when(LPVSPayloadUtil.getRepositoryName(webhookConfig)).thenReturn("A");
-        Mockito.when(webhookConfig.getPullRequestUrl()).thenReturn("A/B");
+        Mockito.when(LPVSPayloadUtil.getRepositoryName(webhookConfig)).thenReturn("C");
+        Mockito.when(webhookConfig.getPullRequestUrl()).thenReturn("A_B");
         ReflectionTestUtils.setField(
                 licenseService, "licenseConflictsSource", licenseConflictsSource);
-        Assertions.assertNotNull(scanossDetectService.checkLicenses(webhookConfig));
+        Mockito.when(licenseService.getLicenseBySpdxIdAndName(anyString(), any()))
+                .thenReturn(
+                        new LPVSLicense() {
+                            {
+                                setLicenseName("MIT");
+                                setLicenseId(1L);
+                                setSpdxId("MIT");
+                            }
+                        });
+        Assertions.assertEquals(scanossDetectService.checkLicenses(webhookConfig).size(), 3);
     }
 
     @Test
@@ -137,11 +146,21 @@ public class LPVSScanossDetectServiceTest {
         Mockito.when(webhookConfig.getHeadCommitSHA()).thenReturn(null);
         Mockito.when(webhookConfig.getRepositoryUrl())
                 .thenReturn("https://github.com/Samsung/LPVS");
-        Mockito.when(webhookConfig.getPullRequestUrl()).thenReturn("A/B");
-        Mockito.when(LPVSPayloadUtil.getRepositoryName(webhookConfig)).thenReturn("A");
+        Mockito.when(webhookConfig.getPullRequestUrl()).thenReturn("A_B");
+        Mockito.when(LPVSPayloadUtil.getRepositoryName(webhookConfig)).thenReturn("C");
         ReflectionTestUtils.setField(
                 licenseService, "licenseConflictsSource", licenseConflictsSource);
-        Assertions.assertNotNull(scanossDetectService.checkLicenses(webhookConfig));
+
+        Mockito.when(licenseService.getLicenseBySpdxIdAndName(anyString(), any()))
+                .thenReturn(
+                        new LPVSLicense() {
+                            {
+                                setLicenseName("MIT");
+                                setLicenseId(1L);
+                                setSpdxId("MIT");
+                            }
+                        });
+        Assertions.assertEquals(scanossDetectService.checkLicenses(webhookConfig).size(), 3);
     }
 
     @Test

--- a/src/test/java/com/lpvs/service/scan/scanner/LPVSScanossDetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/scan/scanner/LPVSScanossDetectServiceTest.java
@@ -15,10 +15,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.*;
@@ -28,6 +31,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
@@ -161,6 +166,16 @@ public class LPVSScanossDetectServiceTest {
                             }
                         });
         Assertions.assertEquals(scanossDetectService.checkLicenses(webhookConfig).size(), 3);
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    public void testCheckLicenseException(CapturedOutput capturedOutput) {
+        Mockito.when(lpvsQueue.getHeadCommitSHA()).thenReturn("AB");
+        Mockito.when(lpvsQueue.getRepositoryUrl()).thenReturn("https://github.com/Samsung/LPVS");
+        scanossDetectService.checkLicenses(lpvsQueue);
+        assertThat(
+                capturedOutput.toString(), containsString("Error while processing Webhook ID = "));
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## Description

The `checkLicenses` has been refactored due to long method.
The unit tests, `testWithNullHeadCommitSHA` and `testWithNullHeadCommitSHADB`, have been fixed to read the existing test file.

## Type of change

- [x] Code cleanup/refactoring

## Testing

This PR was verified by the unit test.

**Test Configuration**:
* Java: v17
* LPVS Release: v1.x.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] My code meets the required code coverage for lines (90% and above)
- [ ] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
