### PR TITLE
refactor: Use LPVSFileUtil API for getReader

### DIFF
--- a/src/main/java/com/lpvs/service/scan/scanner/LPVSScanossDetectService.java
+++ b/src/main/java/com/lpvs/service/scan/scanner/LPVSScanossDetectService.java
@@ -14,6 +14,7 @@ import com.lpvs.entity.LPVSQueue;
 import com.lpvs.repository.LPVSLicenseRepository;
 import com.lpvs.service.LPVSLicenseService;
 import com.lpvs.service.scan.LPVSScanService;
+import com.lpvs.util.LPVSFileUtil;
 import com.lpvs.util.LPVSPayloadUtil;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -244,24 +245,9 @@ public class LPVSScanossDetectService implements LPVSScanService {
      * @throws IOException If an error occurs while creating the BufferedReader object.
      */
     private static Reader getReader(LPVSQueue webhookConfig) throws IOException {
-        String fileName = null;
-        if (webhookConfig.getHeadCommitSHA() == null
-                || webhookConfig.getHeadCommitSHA().isBlank()) {
-            fileName = LPVSPayloadUtil.getPullRequestId(webhookConfig);
-        } else {
-            fileName = webhookConfig.getHeadCommitSHA();
-        }
-
         return Files.newBufferedReader(
                 Paths.get(
-                        System.getProperty("user.home")
-                                + File.separator
-                                + "Results"
-                                + File.separator
-                                + LPVSPayloadUtil.getRepositoryName(webhookConfig)
-                                + File.separator
-                                + fileName
-                                + ".json"));
+                        LPVSFileUtil.getScanResultsJsonFilePath(webhookConfig)));
     }
 
     /**

--- a/src/main/java/com/lpvs/service/scan/scanner/LPVSScanossDetectService.java
+++ b/src/main/java/com/lpvs/service/scan/scanner/LPVSScanossDetectService.java
@@ -246,8 +246,7 @@ public class LPVSScanossDetectService implements LPVSScanService {
      */
     private static Reader getReader(LPVSQueue webhookConfig) throws IOException {
         return Files.newBufferedReader(
-                Paths.get(
-                        LPVSFileUtil.getScanResultsJsonFilePath(webhookConfig)));
+                Paths.get(LPVSFileUtil.getScanResultsJsonFilePath(webhookConfig)));
     }
 
     /**

--- a/src/main/java/com/lpvs/util/LPVSFileUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSFileUtil.java
@@ -171,26 +171,22 @@ public class LPVSFileUtil {
      * @return The file path for storing scan results in JSON format.
      */
     public static String getScanResultsJsonFilePath(LPVSQueue webhookConfig) {
+        String fileName = null;
         if (webhookConfig.getHeadCommitSHA() == null
-                || webhookConfig.getHeadCommitSHA().equals("")) {
-            return System.getProperty("user.home")
-                    + File.separator
-                    + "Results"
-                    + File.separator
-                    + LPVSPayloadUtil.getRepositoryName(webhookConfig)
-                    + File.separator
-                    + LPVSPayloadUtil.getPullRequestId(webhookConfig)
-                    + ".json";
+                || webhookConfig.getHeadCommitSHA().isBlank()) {
+            fileName = LPVSPayloadUtil.getPullRequestId(webhookConfig);
         } else {
-            return System.getProperty("user.home")
-                    + File.separator
-                    + "Results"
-                    + File.separator
-                    + LPVSPayloadUtil.getRepositoryName(webhookConfig)
-                    + File.separator
-                    + webhookConfig.getHeadCommitSHA()
-                    + ".json";
+            fileName = webhookConfig.getHeadCommitSHA();
         }
+
+        return System.getProperty("user.home")
+                + File.separator
+                + "Results"
+                + File.separator
+                + LPVSPayloadUtil.getRepositoryName(webhookConfig)
+                + File.separator
+                + fileName
+                + ".json";
     }
 
     /**

--- a/src/test/java/com/lpvs/util/LPVSFileUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSFileUtilTest.java
@@ -38,14 +38,15 @@ public class LPVSFileUtilTest {
         GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
         ReflectionTestUtils.setField(detail, "filename", "I_am_a_file");
         ReflectionTestUtils.setField(detail, "patch", "+ a\n- b\n@@ -8,7 +8,6 @@\n c");
-        assertEquals(expected,
+        assertEquals(
+                expected,
                 LPVSFileUtil.saveGithubDiffs(
-                                new ArrayList<GHPullRequestFileDetail>() {
-                                    {
-                                        add(detail);
-                                    }
-                                },
-                                webhookConfig));
+                        new ArrayList<GHPullRequestFileDetail>() {
+                            {
+                                add(detail);
+                            }
+                        },
+                        webhookConfig));
     }
 
     @Test
@@ -56,14 +57,15 @@ public class LPVSFileUtilTest {
         GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
         ReflectionTestUtils.setField(detail, "filename", "dir/I_am_a_file");
         ReflectionTestUtils.setField(detail, "patch", "+ a\n- b\n@@ -8,7 +8,6 @@\n c");
-        assertEquals(expected,
+        assertEquals(
+                expected,
                 LPVSFileUtil.saveGithubDiffs(
-                                new ArrayList<GHPullRequestFileDetail>() {
-                                    {
-                                        add(detail);
-                                    }
-                                },
-                                webhookConfig));
+                        new ArrayList<GHPullRequestFileDetail>() {
+                            {
+                                add(detail);
+                            }
+                        },
+                        webhookConfig));
     }
 
     @Test
@@ -74,7 +76,8 @@ public class LPVSFileUtilTest {
         GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
         ReflectionTestUtils.setField(detail, "filename", "I_am_a_file");
         ReflectionTestUtils.setField(detail, "patch", "");
-        assertEquals(expected,
+        assertEquals(
+                expected,
                 LPVSFileUtil.saveGithubDiffs(
                         new ArrayList<GHPullRequestFileDetail>() {
                             {
@@ -184,14 +187,10 @@ public class LPVSFileUtilTest {
     }
 
     private static String getExpectedJsonFilePathWithPullRequestId() {
-        return getExpectedResultsPath()
-                + File.separator
-                + "123.json";
+        return getExpectedResultsPath() + File.separator + "123.json";
     }
 
     private static String getExpectedJsonFilePathWithCommitSHA() {
-        return getExpectedResultsPath()
-                + File.separator
-                + "aaaa.json";
+        return getExpectedResultsPath() + File.separator + "aaaa.json";
     }
 }

--- a/src/test/java/com/lpvs/util/LPVSFileUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSFileUtilTest.java
@@ -7,11 +7,9 @@
 package com.lpvs.util;
 
 import com.lpvs.entity.LPVSQueue;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.github.GHPullRequestFileDetail;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
@@ -20,262 +18,126 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LPVSFileUtilTest {
+    private LPVSQueue webhookConfig = null;
+
+    @BeforeEach
+    public void setUp() {
+        webhookConfig = new LPVSQueue();
+        webhookConfig.setRepositoryUrl("http://test.com/test/test");
+        webhookConfig.setPullRequestUrl("http://test.com/test/test/pull/123");
+    }
 
     @Test
     public void testSaveGithubDiffs() {
-        GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
-        LPVSQueue webhookConfig = new LPVSQueue();
         webhookConfig.setHeadCommitSHA("aaaa");
-        webhookConfig.setRepositoryUrl("http://test.com/test/test");
+        String expected = getExpectedProjectsPathWithCommitSHA();
+
+        GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
         ReflectionTestUtils.setField(detail, "filename", "I_am_a_file");
-        LPVSFileUtil.saveGithubDiffs(
-                new ArrayList<GHPullRequestFileDetail>() {
-                    {
-                        add(detail);
-                    }
-                },
-                webhookConfig);
         ReflectionTestUtils.setField(detail, "patch", "+ a\n- b\n@@ -8,7 +8,6 @@\n c");
-        Assertions.assertFalse(
+        assertEquals(expected,
                 LPVSFileUtil.saveGithubDiffs(
                                 new ArrayList<GHPullRequestFileDetail>() {
                                     {
                                         add(detail);
                                     }
                                 },
-                                webhookConfig)
-                        .contains("Projects//aaaa"));
+                                webhookConfig));
     }
 
     @Test
     public void testSaveGithubDiffsFileNameWithSlash() {
-        GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
-        LPVSQueue webhookConfig = new LPVSQueue();
         webhookConfig.setHeadCommitSHA("aaaa");
-        webhookConfig.setRepositoryUrl("http://test.com/test/test");
-        ReflectionTestUtils.setField(detail, "filename", "dir/I_am_a_file");
-        LPVSFileUtil.saveGithubDiffs(
-                new ArrayList<GHPullRequestFileDetail>() {
-                    {
-                        add(detail);
-                    }
-                },
-                webhookConfig);
+        String expected = getExpectedProjectsPathWithCommitSHA();
 
+        GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
+        ReflectionTestUtils.setField(detail, "filename", "dir/I_am_a_file");
         ReflectionTestUtils.setField(detail, "patch", "+ a\n- b\n@@ -8,7 +8,6 @@\n c");
-        Assertions.assertFalse(
+        assertEquals(expected,
                 LPVSFileUtil.saveGithubDiffs(
                                 new ArrayList<GHPullRequestFileDetail>() {
                                     {
                                         add(detail);
                                     }
                                 },
-                                webhookConfig)
-                        .contains("Projects//aaaa"));
+                                webhookConfig));
     }
 
     @Test
     public void testSaveGithubDiffsEmptyPatchLines() {
-        GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
-        LPVSQueue webhookConfig = new LPVSQueue();
         webhookConfig.setHeadCommitSHA("aaaa");
-        webhookConfig.setRepositoryUrl("http://test.com/test/test");
+        String expected = getExpectedProjectsPathWithCommitSHA();
+
+        GHPullRequestFileDetail detail = new GHPullRequestFileDetail();
         ReflectionTestUtils.setField(detail, "filename", "I_am_a_file");
-        LPVSFileUtil.saveGithubDiffs(
-                new ArrayList<GHPullRequestFileDetail>() {
-                    {
-                        add(detail);
-                    }
-                },
-                webhookConfig);
         ReflectionTestUtils.setField(detail, "patch", "");
-        Assertions.assertFalse(
+        assertEquals(expected,
                 LPVSFileUtil.saveGithubDiffs(
-                                new ArrayList<GHPullRequestFileDetail>() {
-                                    {
-                                        add(detail);
-                                    }
-                                },
-                                webhookConfig)
-                        .contains("Projects//aaaa"));
+                        new ArrayList<GHPullRequestFileDetail>() {
+                            {
+                                add(detail);
+                            }
+                        },
+                        webhookConfig));
     }
 
     @Test
     public void testGetLocalDirectoryPathWithHeadCommitSHA() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(mockWebhookConfig.getHeadCommitSHA()).thenReturn("abcdef123");
+        webhookConfig.setHeadCommitSHA("aaaa");
+        String expected = getExpectedProjectsPathWithCommitSHA();
 
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-
-            String result = LPVSFileUtil.getLocalDirectoryPath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Projects"
-                            + File.separator
-                            + "repoName"
-                            + File.separator
-                            + "abcdef123";
-            assert (result.equals(expectedPath));
-        }
+        assertEquals(expected, LPVSFileUtil.getLocalDirectoryPath(webhookConfig));
     }
 
     @Test
     public void testGetLocalDirectoryPathWithHeadCommitSHAEmpty() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(mockWebhookConfig.getHeadCommitSHA()).thenReturn("");
+        webhookConfig.setHeadCommitSHA("");
+        String expected = getExpectedProjectsPathWithPullRequestId();
 
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getPullRequestId(Mockito.any()))
-                    .thenReturn("1");
-
-            String result = LPVSFileUtil.getLocalDirectoryPath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Projects"
-                            + File.separator
-                            + "repoName"
-                            + File.separator
-                            + "1";
-            assert (result.equals(expectedPath));
-        }
+        assertEquals(expected, LPVSFileUtil.getLocalDirectoryPath(webhookConfig));
     }
 
     @Test
     public void testGetLocalDirectoryPathWithoutHeadCommitSHA() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(mockWebhookConfig.getHeadCommitSHA()).thenReturn(null);
+        webhookConfig.setHeadCommitSHA(null);
+        String expected = getExpectedProjectsPathWithPullRequestId();
 
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getPullRequestId(Mockito.any()))
-                    .thenReturn("pullRequestId");
-
-            String result = LPVSFileUtil.getLocalDirectoryPath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Projects"
-                            + File.separator
-                            + "repoName"
-                            + File.separator
-                            + "pullRequestId";
-            assert (result.equals(expectedPath));
-        }
+        assertEquals(expected, LPVSFileUtil.getLocalDirectoryPath(webhookConfig));
     }
 
     @Test
     public void testGetScanResultsJsonFilePathWithHeadCommitSHA() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(mockWebhookConfig.getHeadCommitSHA()).thenReturn("abcdef123");
+        webhookConfig.setHeadCommitSHA("aaaa");
+        String expected = getExpectedJsonFilePathWithCommitSHA();
 
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-
-            String result = LPVSFileUtil.getScanResultsJsonFilePath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Results"
-                            + File.separator
-                            + "repoName"
-                            + File.separator
-                            + "abcdef123.json";
-            assert (result.equals(expectedPath));
-        }
+        assertEquals(expected, LPVSFileUtil.getScanResultsJsonFilePath(webhookConfig));
     }
 
     @Test
     public void testGetScanResultsJsonFilePathWithHeadCommitSHAEmpty() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(mockWebhookConfig.getHeadCommitSHA()).thenReturn("");
+        webhookConfig.setHeadCommitSHA("");
+        String expected = getExpectedJsonFilePathWithPullRequestId();
 
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getPullRequestId(Mockito.any()))
-                    .thenReturn("1");
-
-            String result = LPVSFileUtil.getScanResultsJsonFilePath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Results"
-                            + File.separator
-                            + "repoName"
-                            + File.separator
-                            + "1.json";
-            assert (result.equals(expectedPath));
-        }
+        assertEquals(expected, LPVSFileUtil.getScanResultsJsonFilePath(webhookConfig));
     }
 
     @Test
     public void testGetScanResultsJsonFilePathWithoutHeadCommitSHA() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        Mockito.when(mockWebhookConfig.getHeadCommitSHA()).thenReturn(null);
+        webhookConfig.setHeadCommitSHA(null);
+        String expected = getExpectedJsonFilePathWithPullRequestId();
 
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getPullRequestId(Mockito.any()))
-                    .thenReturn("pullRequestId");
-
-            String result = LPVSFileUtil.getScanResultsJsonFilePath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Results"
-                            + File.separator
-                            + "repoName"
-                            + File.separator
-                            + "pullRequestId.json";
-            assert (result.equals(expectedPath));
-        }
+        assertEquals(expected, LPVSFileUtil.getScanResultsJsonFilePath(webhookConfig));
     }
 
     @Test
     public void testGetScanResultsDirectoryPath() {
-        LPVSQueue mockWebhookConfig = Mockito.mock(LPVSQueue.class);
-        try (MockedStatic<LPVSPayloadUtil> mocked_static_file_util =
-                mockStatic(LPVSPayloadUtil.class)) {
-            mocked_static_file_util
-                    .when(() -> LPVSPayloadUtil.getRepositoryName(Mockito.any()))
-                    .thenReturn("repoName");
-            String result = LPVSFileUtil.getScanResultsDirectoryPath(mockWebhookConfig);
-            String expectedPath =
-                    System.getProperty("user.home")
-                            + File.separator
-                            + "Results"
-                            + File.separator
-                            + "repoName";
-            assert (result.equals(expectedPath));
-        }
+        webhookConfig.setHeadCommitSHA("aaaa");
+        String expected = getExpectedResultsPath();
+
+        assertEquals(expected, LPVSFileUtil.getScanResultsDirectoryPath(webhookConfig));
     }
 
     @Test
@@ -291,5 +153,45 @@ public class LPVSFileUtilTest {
         LPVSFileUtil.saveFile(fileName, directoryPath, null);
         Boolean result2 = Files.exists(Paths.get(directoryPath, fileName));
         assert (result2.equals(false));
+    }
+
+    private static String getExpectedProjectsPathWithCommitSHA() {
+        return System.getProperty("user.home")
+                + File.separator
+                + "Projects"
+                + File.separator
+                + "test"
+                + File.separator
+                + "aaaa";
+    }
+
+    private static String getExpectedProjectsPathWithPullRequestId() {
+        return System.getProperty("user.home")
+                + File.separator
+                + "Projects"
+                + File.separator
+                + "test"
+                + File.separator
+                + "123";
+    }
+
+    private static String getExpectedResultsPath() {
+        return System.getProperty("user.home")
+                + File.separator
+                + "Results"
+                + File.separator
+                + "test";
+    }
+
+    private static String getExpectedJsonFilePathWithPullRequestId() {
+        return getExpectedResultsPath()
+                + File.separator
+                + "123.json";
+    }
+
+    private static String getExpectedJsonFilePathWithCommitSHA() {
+        return getExpectedResultsPath()
+                + File.separator
+                + "aaaa.json";
     }
 }


### PR DESCRIPTION
# Pull Request

## Description
It's refactored to use LPVSFileUtil API. 
Unit tests of LPVSFileUtil have been updated to use `assertEquals` to improve accuracy.

## Type of change

- [x] Code cleanup/refactoring

## Testing

This PR is verified by the unit tests.

**Test Configuration**:
* Java: v17
* LPVS Release: v1.x.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] My code meets the required code coverage for lines (90% and above)
- [ ] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
