### PR TITLE
feat: Show LPVS logo at the app start

### DIFF
--- a/src/main/java/com/lpvs/LicensePreValidationService.java
+++ b/src/main/java/com/lpvs/LicensePreValidationService.java
@@ -55,6 +55,7 @@ public class LicensePreValidationService {
      */
     public static void main(String[] args) {
         try {
+            log.info(getEmblem());
             ApplicationContext applicationContext =
                     SpringApplication.run(LicensePreValidationService.class, args);
             exitHandler = applicationContext.getBean(LPVSExitHandler.class);
@@ -84,5 +85,40 @@ public class LicensePreValidationService {
         executor.setCorePoolSize(corePoolSize);
         executor.setThreadNamePrefix("LPVS::");
         return executor;
+    }
+
+    /**
+     * Returns the emblem for the License Pre-Validation Service.
+     *
+     * @return the emblem as a String
+     */
+    protected static String getEmblem() {
+        StringBuilder emblem = new StringBuilder();
+        emblem.append("\n");
+        emblem.append(
+                "   .----------------.   .----------------.   .----------------.   .----------------. \n");
+        emblem.append(
+                "  | .--------------. | | .--------------. | | .--------------. | | .--------------. |\n");
+        emblem.append(
+                "  | |   _____      | | | |   ______     | | | | ____   ____  | | | |    _______   | |\n");
+        emblem.append(
+                "  | |  |_   _|     | | | |  |_   __ \\   | | | ||_  _| |_  _| | | | |   /  ___  |  | |\n");
+        emblem.append(
+                "  | |    | |       | | | |    | |__) |  | | | |  \\ \\   / /   | | | |  |  (__ \\_|  | |\n");
+        emblem.append(
+                "  | |    | |   _   | | | |    |  ___/   | | | |   \\ \\ / /    | | | |   '.___`-.   | |\n");
+        emblem.append(
+                "  | |   _| |__/ |  | | | |   _| |_      | | | |    \\ ' /     | | | |  |`\\____) |  | |\n");
+        emblem.append(
+                "  | |  |________|  | | | |  |_____|     | | | |     \\_/      | | | |  |_______.'  | |\n");
+        emblem.append(
+                "  | |              | | | |              | | | |              | | | |              | |\n");
+        emblem.append(
+                "  | '--------------' | | '--------------' | | '--------------' | | '--------------' |\n");
+        emblem.append(
+                "   '----------------'   '----------------'   '----------------'   '----------------' \n");
+        emblem.append(
+                "  :: License Pre-Validation Service ::                                      (v1.5.2)\n");
+        return emblem.toString();
     }
 }

--- a/src/test/java/com/lpvs/LicensePreValidationServiceTest.java
+++ b/src/test/java/com/lpvs/LicensePreValidationServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public class LicensePreValidationServiceTest {
@@ -136,5 +137,11 @@ public class LicensePreValidationServiceTest {
                 .getBean(LPVSExitHandler.class);
         LicensePreValidationService.main(args);
         Mockito.verify(exitHandler, Mockito.times(0)).exit(anyInt());
+    }
+
+    @Test
+    public void testGetEmblem() {
+        String emblem = LicensePreValidationService.getEmblem();
+        assertNotNull(emblem);
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

The current PR adds the feature to show the LPVS logo at the start of the app. Besides that, it contains the app's version number. I tried to take the number from the POM file but failed to do this at the app start - I was successful in getting the version when all was already loaded, but we need it at the app launching time. So, the version number was hardcoded near the logo.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [X] Test Coverage update

## Testing

![image](https://github.com/user-attachments/assets/8eff3573-456a-4f38-b5fd-868bfe58a84f)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My code meets the required code coverage for lines (90% and above)
- [X] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
