### PR TITLE
refactor: Taking the LPVS version from the POM file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
   <distributionManagement>
     <repository>

--- a/src/main/java/com/lpvs/LicensePreValidationService.java
+++ b/src/main/java/com/lpvs/LicensePreValidationService.java
@@ -54,8 +54,7 @@ public class LicensePreValidationService {
      * @param args The command-line arguments passed to the application.
      */
     public static void main(String[] args) {
-        LicensePreValidationService lpvs = new LicensePreValidationService();
-        lpvs.run(args);
+        new LicensePreValidationService().run(args);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,8 @@ github.secret=LPVS
 lpvs.cores=8
 # Number of scan attempts
 lpvs.attempts=4
+# Version of LPVS application (used for versioning)
+lpvs.version=@project.version@
 
 # DB Configuration
 # The name of DB schema

--- a/src/test/java/com/lpvs/LicensePreValidationServiceTest.java
+++ b/src/test/java/com/lpvs/LicensePreValidationServiceTest.java
@@ -7,141 +7,130 @@
 package com.lpvs;
 
 import com.lpvs.util.LPVSExitHandler;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import java.lang.reflect.Field;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 public class LicensePreValidationServiceTest {
-    final int testNumCores = 42;
+
     LicensePreValidationService licensePreValidationService;
 
-    private MockedStatic<SpringApplication> mockedStatic;
+    @Mock SpringApplication springApplication;
+
+    @Mock ConfigurableApplicationContext applicationContext;
+
+    @Mock LPVSExitHandler exitHandler;
+
+    String[] args = new String[0];
 
     @BeforeEach
     void setUp() {
-        licensePreValidationService = new LicensePreValidationService(42);
-        mockedStatic = Mockito.mockStatic(SpringApplication.class);
+        MockitoAnnotations.openMocks(this);
+        licensePreValidationService =
+                new LicensePreValidationService() {
+                    @Override
+                    protected SpringApplication createSpringApplication() {
+                        return springApplication;
+                    }
+                };
+        doNothing().when(springApplication).addInitializers(any());
+        when(springApplication.run()).thenReturn(applicationContext);
     }
 
-    @AfterEach
-    public void tearDown() {
-        if (mockedStatic != null) {
-            mockedStatic.close();
-        }
+    @Test
+    public void testMain() {
+        Mockito.when(applicationContext.getBean(LPVSExitHandler.class)).thenReturn(exitHandler);
+        licensePreValidationService.run(args);
+        Mockito.verify(applicationContext).getBean(LPVSExitHandler.class);
+    }
+
+    @Test
+    public void testMain_IllegalAccessException_N() {
+        when(applicationContext.getBean(LPVSExitHandler.class))
+                .thenReturn(exitHandler)
+                .thenThrow(new IllegalArgumentException("Test IllegalArgumentException"));
+        licensePreValidationService.run(args); // First call - initialize exitHandler
+        licensePreValidationService.run(args); // Second call - IllegalAccessException
+        Mockito.verify(applicationContext, Mockito.times(2)).getBean(LPVSExitHandler.class);
+        Mockito.verify(exitHandler, Mockito.times(1)).exit(anyInt());
+    }
+
+    @Test
+    public void testMain_Exception_N() throws NoSuchFieldException, IllegalAccessException {
+        Mockito.doThrow(new RuntimeException("Test RuntimeException"))
+                .when(applicationContext)
+                .getBean(LPVSExitHandler.class);
+        licensePreValidationService.run(args);
+        Mockito.verify(exitHandler, Mockito.times(0)).exit(anyInt());
+    }
+
+    @Test
+    public void testAddInitializers() {
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(outContent));
+
+        Mockito.when(applicationContext.getBean(LPVSExitHandler.class)).thenReturn(exitHandler);
+        ArgumentCaptor<ApplicationContextInitializer<ConfigurableApplicationContext>> captor =
+                ArgumentCaptor.forClass(ApplicationContextInitializer.class);
+        ConfigurableEnvironment env = mock(ConfigurableEnvironment.class);
+        when(applicationContext.getEnvironment()).thenReturn(env);
+        when(env.getProperty("lpvs.cores", "8")).thenReturn("8");
+        when(env.getProperty("lpvs.version", "Unknown")).thenReturn("1.0.0");
+
+        licensePreValidationService.run(args);
+
+        verify(springApplication).addInitializers(captor.capture());
+
+        ApplicationContextInitializer<ConfigurableApplicationContext> initializer =
+                captor.getValue();
+        initializer.initialize(applicationContext);
+
+        assertTrue(outContent.toString().contains("1.0.0"));
+        System.setOut(originalOut);
+    }
+
+    @Test
+    public void testCreateSpringApplication() {
+        LicensePreValidationService service = new LicensePreValidationService();
+        SpringApplication springApplication = service.createSpringApplication();
+        assertNotNull(springApplication);
     }
 
     @Test
     public void testGetAsyncExecutor() {
         try (MockedConstruction<ThreadPoolTaskExecutor> mocked =
                 mockConstruction(ThreadPoolTaskExecutor.class)) {
-            TaskExecutor executor = licensePreValidationService.getAsyncExecutor();
+            LicensePreValidationService lpvs = new LicensePreValidationService();
+            TaskExecutor executor = lpvs.getAsyncExecutor();
 
             assertEquals(1, mocked.constructed().size());
             ThreadPoolTaskExecutor mocked_constructed_executor = mocked.constructed().get(0);
 
-            // main assert
             assertEquals(executor, mocked_constructed_executor);
-
-            verify(mocked_constructed_executor, times(1)).setCorePoolSize(testNumCores);
+            verify(mocked_constructed_executor, times(1)).setCorePoolSize(8);
             verify(mocked_constructed_executor, times(1)).setThreadNamePrefix("LPVS::");
             verifyNoMoreInteractions(mocked_constructed_executor);
         }
     }
 
     @Test
-    public void testMain() {
-        ConfigurableApplicationContext applicationContext =
-                Mockito.mock(ConfigurableApplicationContext.class);
-        LPVSExitHandler exitHandler = Mockito.mock(LPVSExitHandler.class);
-        String[] args = new String[0];
-
-        mockedStatic
-                .when(() -> SpringApplication.run(LicensePreValidationService.class, args))
-                .thenReturn(applicationContext);
-        Mockito.when(applicationContext.getBean(LPVSExitHandler.class)).thenReturn(exitHandler);
-        LicensePreValidationService.main(args);
-        Mockito.verify(applicationContext).getBean(LPVSExitHandler.class);
-    }
-
-    @Test
-    public void testMain_IllegalAccessException_N()
-            throws NoSuchFieldException, IllegalAccessException {
-        ConfigurableApplicationContext applicationContext =
-                Mockito.mock(ConfigurableApplicationContext.class);
-        LPVSExitHandler exitHandler = Mockito.mock(LPVSExitHandler.class);
-        String[] args = new String[0];
-
-        mockedStatic
-                .when(() -> SpringApplication.run(LicensePreValidationService.class, args))
-                .thenReturn(applicationContext);
-
-        Field exitHandlerField = LicensePreValidationService.class.getDeclaredField("exitHandler");
-        exitHandlerField.setAccessible(true);
-        exitHandlerField.set(null, exitHandler);
-
-        Mockito.doThrow(new IllegalArgumentException("Test IllegalArgumentException"))
-                .when(applicationContext)
-                .getBean(LPVSExitHandler.class);
-        LicensePreValidationService.main(args);
-        Mockito.verify(exitHandler, Mockito.times(1)).exit(anyInt());
-    }
-
-    @Test
-    public void testMain_IllegalAccessException_ExitHandlerIsNull_N() {
-        ConfigurableApplicationContext applicationContext =
-                Mockito.mock(ConfigurableApplicationContext.class);
-        LPVSExitHandler exitHandler = Mockito.mock(LPVSExitHandler.class);
-        String[] args = new String[0];
-
-        mockedStatic
-                .when(() -> SpringApplication.run(LicensePreValidationService.class, args))
-                .thenReturn(applicationContext);
-
-        Mockito.doThrow(new IllegalArgumentException("Test IllegalArgumentException"))
-                .when(applicationContext)
-                .getBean(LPVSExitHandler.class);
-        LicensePreValidationService.main(args);
-        Mockito.verify(exitHandler, Mockito.times(0)).exit(anyInt());
-    }
-
-    @Test
-    public void testMain_Exception_N() throws NoSuchFieldException, IllegalAccessException {
-        ConfigurableApplicationContext applicationContext =
-                Mockito.mock(ConfigurableApplicationContext.class);
-        LPVSExitHandler exitHandler = Mockito.mock(LPVSExitHandler.class);
-        String[] args = new String[0];
-
-        mockedStatic
-                .when(() -> SpringApplication.run(LicensePreValidationService.class, args))
-                .thenReturn(applicationContext);
-
-        Field exitHandlerField = LicensePreValidationService.class.getDeclaredField("exitHandler");
-        exitHandlerField.setAccessible(true);
-        exitHandlerField.set(null, exitHandler);
-
-        Mockito.doThrow(new RuntimeException("Test RuntimeException"))
-                .when(applicationContext)
-                .getBean(LPVSExitHandler.class);
-        LicensePreValidationService.main(args);
-        Mockito.verify(exitHandler, Mockito.times(0)).exit(anyInt());
-    }
-
-    @Test
     public void testGetEmblem() {
-        String emblem = LicensePreValidationService.getEmblem();
+        String emblem = LicensePreValidationService.getEmblem("test");
         assertNotNull(emblem);
+        assertTrue(emblem.contains("test"));
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

Current PR includes changes in how to get the LPVS application's current version.
The proposed approach doesn't need to add any dependency. It uses only `application.properties` and POM files of the project. 
Because of changes in application start, unit tests were also modified and updated.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [X] Test Coverage update

## Testing

By using unit tests and application start. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My code meets the required code coverage for lines (90% and above)
- [X] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
