### PR TITLE
chore: Update years in copyrights

### DIFF
--- a/src/main/java/com/lpvs/LicensePreValidationService.java
+++ b/src/main/java/com/lpvs/LicensePreValidationService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/config/SecurityConfig.java
+++ b/src/main/java/com/lpvs/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/config/package-info.java
+++ b/src/main/java/com/lpvs/config/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/controller/GitHubController.java
+++ b/src/main/java/com/lpvs/controller/GitHubController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/controller/LPVSWebController.java
+++ b/src/main/java/com/lpvs/controller/LPVSWebController.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (с) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/controller/package-info.java
+++ b/src/main/java/com/lpvs/controller/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSDetectedLicense.java
+++ b/src/main/java/com/lpvs/entity/LPVSDetectedLicense.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSDiffFile.java
+++ b/src/main/java/com/lpvs/entity/LPVSDiffFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSFile.java
+++ b/src/main/java/com/lpvs/entity/LPVSFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSLicense.java
+++ b/src/main/java/com/lpvs/entity/LPVSLicense.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSLicenseConflict.java
+++ b/src/main/java/com/lpvs/entity/LPVSLicenseConflict.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.
@@ -45,15 +45,4 @@ public class LPVSLicenseConflict implements Serializable {
     @ManyToOne
     @JoinColumn(name = "conflict_license_id", referencedColumnName = "id", nullable = false)
     private LPVSLicense conflictLicense;
-
-    /**
-     * Constructs a new license conflict with the given repository and conflicting licenses.
-     *
-     * @param repositoryLicense The repository license involved in the conflict.
-     * @param conflictLicense   The conflicting license involved in the conflict.
-     */
-    public LPVSLicenseConflict(LPVSLicense repositoryLicense, LPVSLicense conflictLicense) {
-        this.repositoryLicense = repositoryLicense;
-        this.conflictLicense = conflictLicense;
-    }
 }

--- a/src/main/java/com/lpvs/entity/LPVSPullRequest.java
+++ b/src/main/java/com/lpvs/entity/LPVSPullRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSQueue.java
+++ b/src/main/java/com/lpvs/entity/LPVSQueue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/LPVSResponseWrapper.java
+++ b/src/main/java/com/lpvs/entity/LPVSResponseWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/auth/LPVSLoginMember.java
+++ b/src/main/java/com/lpvs/entity/auth/LPVSLoginMember.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (с) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/auth/LPVSMember.java
+++ b/src/main/java/com/lpvs/entity/auth/LPVSMember.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/auth/MemberProfile.java
+++ b/src/main/java/com/lpvs/entity/auth/MemberProfile.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/auth/package-info.java
+++ b/src/main/java/com/lpvs/entity/auth/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/dashboard/DashBoardElements.java
+++ b/src/main/java/com/lpvs/entity/dashboard/DashBoardElements.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/dashboard/Dashboard.java
+++ b/src/main/java/com/lpvs/entity/dashboard/Dashboard.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/dashboard/DashboardElementsByDate.java
+++ b/src/main/java/com/lpvs/entity/dashboard/DashboardElementsByDate.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/dashboard/package-info.java
+++ b/src/main/java/com/lpvs/entity/dashboard/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/enums/Grade.java
+++ b/src/main/java/com/lpvs/entity/enums/Grade.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/enums/LPVSPullRequestAction.java
+++ b/src/main/java/com/lpvs/entity/enums/LPVSPullRequestAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/enums/LPVSPullRequestStatus.java
+++ b/src/main/java/com/lpvs/entity/enums/LPVSPullRequestStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/enums/LPVSVcs.java
+++ b/src/main/java/com/lpvs/entity/enums/LPVSVcs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/enums/OAuthAttributes.java
+++ b/src/main/java/com/lpvs/entity/enums/OAuthAttributes.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/enums/package-info.java
+++ b/src/main/java/com/lpvs/entity/enums/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.
@@ -15,7 +15,7 @@
  * Enums in this package may include but are not limited to:
  * - Actions related to pull requests (e.g., opening, closing)
  * - Status of pull request scans (e.g., completed, scanning)
- * - Version control systems (e.g., GitHub, GitLab)
+ * - Version control systems (e.g., GitHub)
  * - OAuth attributes for various authentication providers (e.g., Google, Naver, Kakao)
  * </p><p>
  * Enums in this package may have additional methods and functionalities to facilitate

--- a/src/main/java/com/lpvs/entity/history/HistoryEntity.java
+++ b/src/main/java/com/lpvs/entity/history/HistoryEntity.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/history/HistoryPageEntity.java
+++ b/src/main/java/com/lpvs/entity/history/HistoryPageEntity.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/history/LPVSHistory.java
+++ b/src/main/java/com/lpvs/entity/history/LPVSHistory.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/history/package-info.java
+++ b/src/main/java/com/lpvs/entity/history/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/package-info.java
+++ b/src/main/java/com/lpvs/entity/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/result/LPVSResult.java
+++ b/src/main/java/com/lpvs/entity/result/LPVSResult.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/result/LPVSResultFile.java
+++ b/src/main/java/com/lpvs/entity/result/LPVSResultFile.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/result/LPVSResultInfo.java
+++ b/src/main/java/com/lpvs/entity/result/LPVSResultInfo.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/entity/result/package-info.java
+++ b/src/main/java/com/lpvs/entity/result/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/exception/ErrorResponse.java
+++ b/src/main/java/com/lpvs/exception/ErrorResponse.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/exception/LoginFailedException.java
+++ b/src/main/java/com/lpvs/exception/LoginFailedException.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/exception/PageControllerAdvice.java
+++ b/src/main/java/com/lpvs/exception/PageControllerAdvice.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/exception/WrongAccessException.java
+++ b/src/main/java/com/lpvs/exception/WrongAccessException.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/exception/package-info.java
+++ b/src/main/java/com/lpvs/exception/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/package-info.java
+++ b/src/main/java/com/lpvs/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/LPVSDetectedLicenseRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSDetectedLicenseRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/LPVSLicenseConflictRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSLicenseConflictRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/LPVSLicenseRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSLicenseRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/LPVSMemberRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSMemberRepository.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/LPVSPullRequestRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSPullRequestRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/LPVSQueueRepository.java
+++ b/src/main/java/com/lpvs/repository/LPVSQueueRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/repository/package-info.java
+++ b/src/main/java/com/lpvs/repository/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSGitHubConnectionService.java
+++ b/src/main/java/com/lpvs/service/LPVSGitHubConnectionService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSGitHubService.java
+++ b/src/main/java/com/lpvs/service/LPVSGitHubService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSLicenseService.java
+++ b/src/main/java/com/lpvs/service/LPVSLicenseService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSLoginCheckService.java
+++ b/src/main/java/com/lpvs/service/LPVSLoginCheckService.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSQueueProcessorService.java
+++ b/src/main/java/com/lpvs/service/LPVSQueueProcessorService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSQueueService.java
+++ b/src/main/java/com/lpvs/service/LPVSQueueService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/LPVSStatisticsService.java
+++ b/src/main/java/com/lpvs/service/LPVSStatisticsService.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/OAuthService.java
+++ b/src/main/java/com/lpvs/service/OAuthService.java
@@ -1,5 +1,6 @@
 /**
- * Copyright 2023 Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2023, Basaeng, kyudori, hwan5180, quswjdgma83
+ * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/package-info.java
+++ b/src/main/java/com/lpvs/service/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/scan/LPVSDetectService.java
+++ b/src/main/java/com/lpvs/service/scan/LPVSDetectService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/scan/scanner/LPVSScanossDetectService.java
+++ b/src/main/java/com/lpvs/service/scan/scanner/LPVSScanossDetectService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/service/scan/scanner/package-info.java
+++ b/src/main/java/com/lpvs/service/scan/scanner/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/util/LPVSCommentUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSCommentUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/util/LPVSExitHandler.java
+++ b/src/main/java/com/lpvs/util/LPVSExitHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/util/LPVSFileUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSFileUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/util/LPVSPayloadUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSPayloadUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/main/java/com/lpvs/util/package-info.java
+++ b/src/main/java/com/lpvs/util/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/LicensePreValidationServiceTest.java
+++ b/src/test/java/com/lpvs/LicensePreValidationServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/config/SecurityConfigTest.java
+++ b/src/test/java/com/lpvs/config/SecurityConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/controller/GitHubControllerTest.java
+++ b/src/test/java/com/lpvs/controller/GitHubControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/controller/LPVSWebControllerTest.java
+++ b/src/test/java/com/lpvs/controller/LPVSWebControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSDetectedLicenseTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSDetectedLicenseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSDiffFileTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSDiffFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSFileTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSLicenseConflictTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSLicenseConflictTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSLicenseTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSLicenseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSLoginMemberTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSLoginMemberTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSMemberTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSMemberTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSPullRequestTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSPullRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSQueueTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSQueueTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/LPVSResponseWrapperTest.java
+++ b/src/test/java/com/lpvs/entity/LPVSResponseWrapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/auth/MemberProfileTest.java
+++ b/src/test/java/com/lpvs/entity/auth/MemberProfileTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
- * <p>
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
+ *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.
  */

--- a/src/test/java/com/lpvs/entity/dashboard/DashBoardElementsTest.java
+++ b/src/test/java/com/lpvs/entity/dashboard/DashBoardElementsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/dashboard/DashboardElementsByDateTest.java
+++ b/src/test/java/com/lpvs/entity/dashboard/DashboardElementsByDateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/dashboard/DashboardTest.java
+++ b/src/test/java/com/lpvs/entity/dashboard/DashboardTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/enums/GradeTest.java
+++ b/src/test/java/com/lpvs/entity/enums/GradeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/enums/LPVSPullRequestActionTest.java
+++ b/src/test/java/com/lpvs/entity/enums/LPVSPullRequestActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/enums/LPVSPullRequestStatusTest.java
+++ b/src/test/java/com/lpvs/entity/enums/LPVSPullRequestStatusTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/enums/LPVSVcsTest.java
+++ b/src/test/java/com/lpvs/entity/enums/LPVSVcsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/enums/OAuthAttributesTest.java
+++ b/src/test/java/com/lpvs/entity/enums/OAuthAttributesTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
- * <p>
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
+ *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.
  */

--- a/src/test/java/com/lpvs/entity/history/HistoryEntityTest.java
+++ b/src/test/java/com/lpvs/entity/history/HistoryEntityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/history/HistoryPageEntityTest.java
+++ b/src/test/java/com/lpvs/entity/history/HistoryPageEntityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/history/LPVSHistoryTest.java
+++ b/src/test/java/com/lpvs/entity/history/LPVSHistoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/results/LPVSResultFileTest.java
+++ b/src/test/java/com/lpvs/entity/results/LPVSResultFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/results/LPVSResultInfoTest.java
+++ b/src/test/java/com/lpvs/entity/results/LPVSResultInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/entity/results/LPVSResultTest.java
+++ b/src/test/java/com/lpvs/entity/results/LPVSResultTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/exception/ErrorResponseTest.java
+++ b/src/test/java/com/lpvs/exception/ErrorResponseTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/exception/LoginFailedExceptionTest.java
+++ b/src/test/java/com/lpvs/exception/LoginFailedExceptionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/exception/PageControllerAdviceTest.java
+++ b/src/test/java/com/lpvs/exception/PageControllerAdviceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/exception/WrongAccessExceptionTest.java
+++ b/src/test/java/com/lpvs/exception/WrongAccessExceptionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/LPVSGitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSGitHubServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/LPVSLicenseServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSLicenseServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/LPVSLoginCheckServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSLoginCheckServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/LPVSQueueProcessorServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSQueueProcessorServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/LPVSQueueServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSQueueServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/LPVSStatisticsServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSStatisticsServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/OAuthServiceTest.java
+++ b/src/test/java/com/lpvs/service/OAuthServiceTest.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
- * <p>
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
+ *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.
  */

--- a/src/test/java/com/lpvs/service/scan/LPVSDetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/scan/LPVSDetectServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/service/scan/scanner/LPVSScanossDetectServiceTest.java
+++ b/src/test/java/com/lpvs/service/scan/scanner/LPVSScanossDetectServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/util/LPVSCommentUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSCommentUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/util/LPVSExitHandlerTest.java
+++ b/src/test/java/com/lpvs/util/LPVSExitHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/util/LPVSFileUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSFileUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2022-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/util/LPVSPayloadUtilTest.java
+++ b/src/test/java/com/lpvs/util/LPVSPayloadUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.

--- a/src/test/java/com/lpvs/util/LPVSPayloadUtilTestFuzzer.java
+++ b/src/test/java/com/lpvs/util/LPVSPayloadUtilTestFuzzer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (c) 2023-2024, Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Use of this source code is governed by a MIT license that can be
  * found in the LICENSE file.


### PR DESCRIPTION
# Pull Request

## Description

Current PR contains year updates in Copyright (c) comments.
The rule we will use is `Use the earliest date of publication. For example, if you first published on your blog in 2012, when you amend the blog content or add to it, use a range of dates such as 2012–2023.`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [X] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update
