### PR TITLE
feat: Add default endpoint that forward POST requests to /webhooks

### DIFF
--- a/doc/docs/user-guide/service/database.md
+++ b/doc/docs/user-guide/service/database.md
@@ -32,7 +32,7 @@ sudo mysql
 
 !!! note
 
-    Replace 'username' and 'password' with your preferred values. However, in the example below, they are kept as placeholders for the sake of clarity:
+    Replace `username` and `password` with your preferred values. However, in the example below, they are kept as placeholders for the sake of clarity.
 
 ```sql
 create database lpvs;

--- a/doc/docs/user-guide/service/database.md
+++ b/doc/docs/user-guide/service/database.md
@@ -28,20 +28,24 @@ sudo service mysql start
 sudo mysql
 ```
 
-* Run the following commands in the MySQL command line interface to create the necessary database and user:
+* Run the following commands in the MySQL command line interface to create the necessary database and user.
+
+!!! note
+
+    Replace 'username' and 'password' with your preferred values. However, in the example below, they are kept as placeholders for the sake of clarity:
 
 ```sql
-mysql> create database lpvs;
-mysql> create user username;
-mysql> grant all on lpvs.* to username;
-mysql> alter user username identified by 'password';
-mysql> exit;
+create database lpvs;
+create user username;
+grant all on lpvs.* to username;
+alter user username identified by 'password';
+exit;
 ```
 
-* (**Optional**) If you have an existing dump file, import it into the newly created database using the command:
+* (**Optional**) If using the provided dump file, make sure to run the following command from the repository's base folder. If using a different dump file, specify its path in the command. After running the command, you will be prompted to enter the password set in the previous step:
 
 ```bash
-mysql -u[username] -p[password] < /path/to/dump/file/database_dump.sql
+mysql -u [username] -p < /src/main/resources/database_dump.sql
 ```
 
 * (**Optional**) Fill in the `lpvs_license_list` and `lpvs_license_conflicts` tables according to the [Database customization guideline](../config/database.md).

--- a/doc/docs/user-guide/service/webhook.md
+++ b/doc/docs/user-guide/service/webhook.md
@@ -44,7 +44,7 @@ Follow the next steps:
 
 ![step2](../../img/webhook/step_1_2.png)
 
-- Fill in the `Payload URL` with: <URL where LPVS is running>.
+- Fill in the `Payload URL` with URL where LPVS is running.
 
 !!! note
 

--- a/doc/docs/user-guide/service/webhook.md
+++ b/doc/docs/user-guide/service/webhook.md
@@ -44,7 +44,7 @@ Follow the next steps:
 
 ![step2](../../img/webhook/step_1_2.png)
 
-- Fill in the `Payload URL` with: `http://<IP where LPVS is running>/webhooks`.
+- Fill in the `Payload URL` with: <URL where LPVS is running>.
 
 !!! note
 

--- a/doc/lpvs-api.yaml
+++ b/doc/lpvs-api.yaml
@@ -48,6 +48,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/WebhookResponseForbidden'
 
+  /:
+    post:
+      tags:
+        - GitHub Webhooks API
+      summary: Forward to Start Scan
+      description: Forwards the request to the `/webhooks` endpoint.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookRequest'
+      responses:
+        '200':
+          description: 200 OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookResponseOK'
+        '403':
+          description: 403 Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookResponseForbidden'
+
   /scan/{gitHubOrg}/{gitHubRepo}/{prNumber}:
     post:
       tags:

--- a/src/main/java/com/lpvs/controller/GitHubController.java
+++ b/src/main/java/com/lpvs/controller/GitHubController.java
@@ -38,6 +38,10 @@ import java.util.Optional;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Controller class for handling GitHub webhook events and single scan requests.
@@ -125,6 +129,26 @@ public class GitHubController {
         this.queueRepository = queueRepository;
         this.GITHUB_SECRET = GITHUB_SECRET;
         this.exitHandler = exitHandler;
+    }
+
+    /**
+     * @brief Default endpoint that forwards POST requests to the `/webhooks` endpoint.
+     *
+     * This method serves as a "default" POST endpoint that doesn't have any specific path assigned.
+     * It forwards any requests to the `/webhooks` endpoint using Spring's `RequestDispatcher`.
+     * Implemented to simplify Github webhook configuration.
+     *
+     * @param request The HttpServletRequest object representing the incoming request.
+     * @param response The HttpServletResponse object for the outgoing response.
+     * @throws ServletException If an error occurs during request forwarding.
+     * @throws IOException If an input or output error occurs during request forwarding.
+     */
+    @RequestMapping(method = RequestMethod.POST)
+    public void forwardToWebhook(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // Forward the request to the /webhooks endpoint
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/webhooks");
+        dispatcher.forward(request, response);
     }
 
     /**

--- a/src/main/java/com/lpvs/controller/GitHubController.java
+++ b/src/main/java/com/lpvs/controller/GitHubController.java
@@ -132,11 +132,10 @@ public class GitHubController {
     }
 
     /**
-     * @brief Default endpoint that forwards POST requests to the `/webhooks` endpoint.
-     *
+     * Default endpoint that forwards POST requests to the `/webhooks` endpoint.
      * This method serves as a "default" POST endpoint that doesn't have any specific path assigned.
      * It forwards any requests to the `/webhooks` endpoint using Spring's `RequestDispatcher`.
-     * Implemented to simplify Github webhook configuration.
+     * Implemented to simplify GitHub webhook configuration.
      *
      * @param request The HttpServletRequest object representing the incoming request.
      * @param response The HttpServletResponse object for the outgoing response.
@@ -146,7 +145,7 @@ public class GitHubController {
     @RequestMapping(method = RequestMethod.POST)
     public void forwardToWebhook(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        // Forward the request to the /webhooks endpoint
+        // Forward the request to the `/webhooks` endpoint
         RequestDispatcher dispatcher = request.getRequestDispatcher("/webhooks");
         dispatcher.forward(request, response);
     }

--- a/src/test/java/com/lpvs/controller/GitHubControllerTest.java
+++ b/src/test/java/com/lpvs/controller/GitHubControllerTest.java
@@ -81,17 +81,11 @@ public class GitHubControllerTest {
 
     @Test
     void ForwardToWebhookTest() throws ServletException, IOException {
-
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         HttpServletResponse mockResponse = mock(HttpServletResponse.class);
         RequestDispatcher mockDispatcher = mock(RequestDispatcher.class);
-
         when(mockRequest.getRequestDispatcher("/webhooks")).thenReturn(mockDispatcher);
-
-        // Act
         gitHubController.forwardToWebhook(mockRequest, mockResponse);
-
-        // Assert
         verify(mockRequest).getRequestDispatcher("/webhooks");
         verify(mockDispatcher).forward(mockRequest, mockResponse);
     }

--- a/src/test/java/com/lpvs/controller/GitHubControllerTest.java
+++ b/src/test/java/com/lpvs/controller/GitHubControllerTest.java
@@ -14,6 +14,11 @@ import com.lpvs.service.LPVSGitHubService;
 import com.lpvs.service.LPVSQueueService;
 
 import com.lpvs.util.LPVSExitHandler;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
@@ -28,9 +33,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.lang.reflect.Method;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @Slf4j
@@ -70,6 +78,23 @@ public class GitHubControllerTest {
                     mocked_queueRepo,
                     "LPVS",
                     exitHandler);
+
+    @Test
+    void ForwardToWebhookTest() throws ServletException, IOException {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        RequestDispatcher mockDispatcher = mock(RequestDispatcher.class);
+
+        when(mockRequest.getRequestDispatcher("/webhooks")).thenReturn(mockDispatcher);
+
+        // Act
+        gitHubController.forwardToWebhook(mockRequest, mockResponse);
+
+        // Assert
+        verify(mockRequest).getRequestDispatcher("/webhooks");
+        verify(mockDispatcher).forward(mockRequest, mockResponse);
+    }
 
     @Test
     public void noSignatureTest() {


### PR DESCRIPTION
# Pull Request

## Description

In order to simplify setup for end user, default endpoint that forward requests added. Now user just need to paste LPVS URL in github webhooks without adding '/webhooks' endpoint. 
Corresponding guide updated.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [x] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [x] Test Coverage update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Java: v17
* LPVS Release: v1.x.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code meets the required code coverage for lines (90% and above)
- [x] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
