### PR TITLE
fix: Update the clusterfuzzlite docker container

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:0a35a200381bf7ebda008131f8b1b7f19fd9c1bba1cfbaa9e4068c124761ecfd
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:e57ec446d50da82d34047f0da16fd667ef40b5e8752447bfae37d4b129fa3ace
 
 RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.zip -o maven.zip && \
     unzip maven.zip -d $SRC/maven && \


### PR DESCRIPTION
# Pull Request

## Description
The new docker container supports the build using java 17. Therefore, the Fuzzer can be successfully launched.

Fixes #405

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI system update

**Test Configuration**:
* Java: v17
* LPVS Release: v1.5.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] My code meets the required code coverage for lines (90% and above)
- [ ] My code meets the required code coverage for branches (80% and above)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
