### PR TITLE
fix: Incorrect conversion to string when equals to null

### DIFF
--- a/src/main/java/com/lpvs/util/LPVSFileUtil.java
+++ b/src/main/java/com/lpvs/util/LPVSFileUtil.java
@@ -198,7 +198,7 @@ public class LPVSFileUtil {
                     + File.separator
                     + LPVSPayloadUtil.getRepositoryName(webhookConfig)
                     + File.separator
-                    + webhookConfig.getId().toString()
+                    + webhookConfig.getId()
                     + "-"
                     + LPVSPayloadUtil.getPullRequestId(webhookConfig);
         } else {
@@ -210,7 +210,7 @@ public class LPVSFileUtil {
                     + File.separator
                     + LPVSPayloadUtil.getRepositoryName(webhookConfig)
                     + File.separator
-                    + webhookConfig.getId().toString()
+                    + webhookConfig.getId()
                     + "-"
                     + webhookConfig.getHeadCommitSHA();
         }


### PR DESCRIPTION
# Pull Request

## Description

Current PR contains a bug fix for the incorrect conversion to string when the queue element equals null.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update

## Testing

Checked by functional tests.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My code meets the required code coverage for lines (90% and above)
- [X] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
