### PR TITLE
fix: Take SPDX ID from GitHub API when searching for the license

### DIFF
--- a/src/main/java/com/lpvs/service/LPVSGitHubService.java
+++ b/src/main/java/com/lpvs/service/LPVSGitHubService.java
@@ -357,9 +357,9 @@ public class LPVSGitHubService {
      * Retrieves the license of the GitHub repository associated with the pull request.
      *
      * @param webhookConfig LPVSQueue configuration for the pull request.
-     * @return License key of the GitHub repository or null if not available.
+     * @return License SPDX ID and name for the GitHub repository or null if not available.
      */
-    public String getRepositoryLicense(LPVSQueue webhookConfig) {
+    public String[] getRepositoryLicense(LPVSQueue webhookConfig) {
         try {
             String repositoryName = LPVSPayloadUtil.getRepositoryName(webhookConfig);
             String repositoryOrganization =
@@ -371,7 +371,7 @@ public class LPVSGitHubService {
             if (license == null) {
                 return null;
             } else {
-                return license.getKey();
+                return new String[] {license.getSpdxId(), license.getName()};
             }
         } catch (IOException | IllegalArgumentException e) {
             log.error("Can't authorize getRepositoryLicense(): " + e.getMessage());

--- a/src/main/java/com/lpvs/service/webhook/LPVSWebhookServiceImpl.java
+++ b/src/main/java/com/lpvs/service/webhook/LPVSWebhookServiceImpl.java
@@ -146,12 +146,13 @@ public class LPVSWebhookServiceImpl implements LPVSWebhookService {
                     filePath = filePath.split(":::::")[0];
                 }
                 // check repository license
-                String repositoryLicense = gitHubService.getRepositoryLicense(webhookConfig);
+                String[] repositoryLicense = gitHubService.getRepositoryLicense(webhookConfig);
 
                 if (repositoryLicense != null) {
                     LPVSLicense repoLicense =
                             licenseService.getLicenseBySpdxIdAndName(
-                                    repositoryLicense, Optional.empty());
+                                    repositoryLicense[0],
+                                    Optional.ofNullable(repositoryLicense[1]));
                     webhookConfig.setRepositoryLicense(repoLicense.getSpdxId());
                 } else {
                     webhookConfig.setRepositoryLicense(null);

--- a/src/test/java/com/lpvs/service/LPVSGitHubServiceTest.java
+++ b/src/test/java/com/lpvs/service/LPVSGitHubServiceTest.java
@@ -3829,7 +3829,8 @@ public class LPVSGitHubServiceTest {
             } catch (IOException e) {
                 log.error("mocked_repo.getLicense error " + e);
             }
-            when(mocked_license.getKey()).thenReturn(test_license_key);
+            when(mocked_license.getSpdxId()).thenReturn(test_license_key);
+            when(mocked_license.getName()).thenReturn(test_license_key);
         }
 
         @Test
@@ -3841,7 +3842,8 @@ public class LPVSGitHubServiceTest {
                         .thenReturn(mocked_instance_gh);
 
                 // main test
-                assertEquals(test_license_key, gh_service.getRepositoryLicense(webhookConfig));
+                assertEquals(
+                        2, Arrays.stream(gh_service.getRepositoryLicense(webhookConfig)).count());
 
                 // verification of calling methods on `Mock`s
                 // `mocked_static_gh` verify
@@ -3869,7 +3871,8 @@ public class LPVSGitHubServiceTest {
                 verifyNoMoreInteractions(mocked_repo);
 
                 // `mocked_license` verify
-                verify(mocked_license, times(1)).getKey();
+                verify(mocked_license, times(1)).getSpdxId();
+                verify(mocked_license, times(1)).getName();
                 verifyNoMoreInteractions(mocked_license);
             }
         }
@@ -4032,7 +4035,8 @@ public class LPVSGitHubServiceTest {
                         .thenReturn(mocked_instance_gh);
 
                 // main test
-                assertEquals(test_license_key, gh_service.getRepositoryLicense(webhookConfig));
+                assertEquals(
+                        2, Arrays.stream(gh_service.getRepositoryLicense(webhookConfig)).count());
 
                 // verification of calling methods on `Mock`s
                 // `mocked_static_gh` verify
@@ -4064,7 +4068,8 @@ public class LPVSGitHubServiceTest {
                 verifyNoMoreInteractions(mocked_repo);
 
                 // `mocked_license` verify
-                verify(mocked_license, times(1)).getKey();
+                verify(mocked_license, times(1)).getSpdxId();
+                verify(mocked_license, times(1)).getName();
                 verifyNoMoreInteractions(mocked_license);
             }
         }

--- a/src/test/java/com/lpvs/service/webhook/LPVSWebhookServiceImplTest.java
+++ b/src/test/java/com/lpvs/service/webhook/LPVSWebhookServiceImplTest.java
@@ -272,10 +272,11 @@ public class LPVSWebhookServiceImplTest {
             when(mockGitHubService.getPullRequestFiles(webhookConfigMain))
                     .thenReturn(filePathTestNoDeletion);
             when(mockGitHubService.getRepositoryLicense(webhookConfigMain))
-                    .thenReturn(licenseNameTest);
+                    .thenReturn(new String[] {spdxIdTest, licenseNameTest});
 
             mockLicenseService = mock(LPVSLicenseService.class);
-            when(mockLicenseService.getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty()))
+            when(mockLicenseService.getLicenseBySpdxIdAndName(
+                            spdxIdTest, Optional.of(licenseNameTest)))
                     .thenReturn(lpvsLicenseTest);
 
             mockDetectService = mock(LPVSDetectService.class);
@@ -312,7 +313,7 @@ public class LPVSWebhookServiceImplTest {
             verify(mockGitHubService, times(1)).getPullRequestFiles(webhookConfigMain);
             verify(mockGitHubService, times(1)).getRepositoryLicense(webhookConfigMain);
             verify(mockLicenseService, times(1))
-                    .getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty());
+                    .getLicenseBySpdxIdAndName(spdxIdTest, Optional.of(licenseNameTest));
             try {
                 verify(mockDetectService, times(1))
                         .runScan(webhookConfigMain, filePathTestNoDeletion);
@@ -374,10 +375,11 @@ public class LPVSWebhookServiceImplTest {
             when(mockGitHubService.getPullRequestFiles(webhookConfigMain))
                     .thenReturn(filePathTestWithDeletion);
             when(mockGitHubService.getRepositoryLicense(webhookConfigMain))
-                    .thenReturn(licenseNameTest);
+                    .thenReturn(new String[] {spdxIdTest, licenseNameTest});
 
             mockLicenseService = mock(LPVSLicenseService.class);
-            when(mockLicenseService.getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty()))
+            when(mockLicenseService.getLicenseBySpdxIdAndName(
+                            spdxIdTest, Optional.of(licenseNameTest)))
                     .thenReturn(lpvsLicenseTest);
 
             mockDetectService = mock(LPVSDetectService.class);
@@ -415,7 +417,7 @@ public class LPVSWebhookServiceImplTest {
             verify(mockGitHubService, times(1)).getPullRequestFiles(webhookConfigMain);
             verify(mockGitHubService, times(1)).getRepositoryLicense(webhookConfigMain);
             verify(mockLicenseService, times(1))
-                    .getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty());
+                    .getLicenseBySpdxIdAndName(spdxIdTest, Optional.of(licenseNameTest));
             try {
                 verify(mockDetectService, times(1))
                         .runScan(webhookConfigMain, filePathTestWithDeletionTruncated);
@@ -474,10 +476,11 @@ public class LPVSWebhookServiceImplTest {
             when(mockGitHubService.getPullRequestFiles(webhookConfigMain))
                     .thenReturn(filePathTestNoDeletion);
             when(mockGitHubService.getRepositoryLicense(webhookConfigMain))
-                    .thenReturn(licenseNameTest);
+                    .thenReturn(new String[] {spdxIdTest, licenseNameTest});
 
             mockLicenseService = mock(LPVSLicenseService.class);
-            when(mockLicenseService.getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty()))
+            when(mockLicenseService.getLicenseBySpdxIdAndName(
+                            spdxIdTest, Optional.of(licenseNameTest)))
                     .thenReturn(lpvsLicenseTest);
 
             mockDetectService = mock(LPVSDetectService.class);
@@ -519,9 +522,7 @@ public class LPVSWebhookServiceImplTest {
             verify(mockGitHubService, times(1)).getPullRequestFiles(webhookConfigMain);
             verify(mockGitHubService, times(1)).getRepositoryLicense(webhookConfigMain);
             verify(mockLicenseService, times(1))
-                    .getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty());
-            verify(mockLicenseService, times(1))
-                    .getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty());
+                    .getLicenseBySpdxIdAndName(spdxIdTest, Optional.of(licenseNameTest));
             try {
                 verify(mockDetectService, times(1))
                         .runScan(webhookConfigMain, filePathTestNoDeletion);
@@ -583,10 +584,11 @@ public class LPVSWebhookServiceImplTest {
             when(mockGitHubService.getPullRequestFiles(webhookConfigMain))
                     .thenReturn(filePathTestWithDeletion);
             when(mockGitHubService.getRepositoryLicense(webhookConfigMain))
-                    .thenReturn(licenseNameTest);
+                    .thenReturn(new String[] {spdxIdTest, licenseNameTest});
 
             mockLicenseService = mock(LPVSLicenseService.class);
-            when(mockLicenseService.getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty()))
+            when(mockLicenseService.getLicenseBySpdxIdAndName(
+                            spdxIdTest, Optional.of(licenseNameTest)))
                     .thenReturn(lpvsLicenseTest);
 
             mockDetectService = mock(LPVSDetectService.class);
@@ -624,9 +626,7 @@ public class LPVSWebhookServiceImplTest {
             verify(mockGitHubService, times(1)).getPullRequestFiles(webhookConfigMain);
             verify(mockGitHubService, times(1)).getRepositoryLicense(webhookConfigMain);
             verify(mockLicenseService, times(1))
-                    .getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty());
-            verify(mockLicenseService, times(1))
-                    .getLicenseBySpdxIdAndName(licenseNameTest, Optional.empty());
+                    .getLicenseBySpdxIdAndName(spdxIdTest, Optional.of(licenseNameTest));
             try {
                 verify(mockDetectService, times(1))
                         .runScan(webhookConfigMain, filePathTestWithDeletionTruncated);


### PR DESCRIPTION
# Pull Request

## Description

The current pull request improves the way to take the license of the repository from GitHub (using SPDX ID, not a license key as previously). This change is related to the upgrade of the GitHub library #631 .

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update

## Testing

Checked locally.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My code meets the required code coverage for lines (90% and above)
- [X] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
