### PR TITLE
docs: Remove unactual badges from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@
 
 # License Pre-Validation Service
 
-[![Build](https://github.com/samsung/lpvs/workflows/Build/badge.svg)](https://github.com/samsung/lpvs/actions?query=workflow%3ABuild)
 [![CodeQL Analysis](https://github.com/Samsung/LPVS/workflows/CodeQL%20Analysis/badge.svg)](https://github.com/Samsung/LPVS/actions?query=workflow%3A%22CodeQL+Analysis%22)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6309/badge)](https://www.bestpractices.dev/projects/6309)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Samsung/LPVS/badge)](https://api.securityscorecards.dev/projects/github.com/Samsung/LPVS)
 [![Release](https://img.shields.io/github/v/release/samsung/lpvs.svg)](https://github.com/Samsung/LPVS/releases)
 [![LICENSE](https://img.shields.io/github/license/samsung/lpvs.svg)](https://github.com/Samsung/LPVS/blob/main/LICENSE)
 [![codecov](https://codecov.io/gh/Samsung/LPVS/graph/badge.svg?token=XTD749ITNF)](https://codecov.io/gh/Samsung/LPVS)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7127519.svg)](https://doi.org/10.5281/zenodo.7127519)
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Description

Remove unactual badges:
- build: non-significant badge. 
- doi: stopped to work properly - I can't upload new releases on zenodo website because of space limitation. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [X] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update

