### PR TITLE
fix: Fix conflicting versions

### DIFF
--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -130,7 +130,10 @@ click==8.1.8 \
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-    # via mkdocs-material
+    # via
+    #   click
+    #   mkdocs
+    #   mkdocs-material
 essentials==1.1.5 \
     --hash=sha256:8736f738bb2c51d5069b2de2cf9146f7d402f25f9f95636781e59a422c908c46 \
     --hash=sha256:905fa4a69fcd2b2cf41ecc6cc65827e30c87ef91f3f5c71540bcc5e984fa8360
@@ -143,9 +146,9 @@ ghp-import==2.1.0 \
     --hash=sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619 \
     --hash=sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343
     # via mkdocs
-h11==0.16.0 \
-    --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
-    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
     # via httpcore
 httpcore==1.0.7 \
     --hash=sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c \
@@ -260,7 +263,6 @@ mkdocs==1.6.1 \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \
     --hash=sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e
     # via
-    #   -r requirements.in
     #   mkdocs-material
     #   neoteroi-mkdocs
 mkdocs-get-deps==0.2.0 \
@@ -304,9 +306,7 @@ pygments==2.19.1 \
 pymdown-extensions==10.14.3 \
     --hash=sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9 \
     --hash=sha256:41e576ce3f5d650be59e900e4ceff231e0aed2a88cf30acaee41e02f063a061b
-    # via
-    #   -r requirements.in
-    #   mkdocs-material
+    # via mkdocs-material
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427


### PR DESCRIPTION
# Pull Request

## Description

Fixed conflicting versions of dependencies for generating docs.

```
ERROR: Cannot install -r doc/requirements-docs.txt (line 150) and h11==0.16.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested h11==0.16.0
    httpcore 1.0.7 depends on h11<0.15 and >=0.13
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [ ] Documentation update
- [ ] This change requires a documentation update
- [ ] CI system update
- [ ] Test Coverage update
- [ ] Version update (release)

## Testing

```
pip install --require-hashes -r doc/requirements-docs.txt
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My code meets the required code coverage for lines (90% and above)
- [ ] My code meets the required code coverage for branches (80% and above)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
